### PR TITLE
[Feat] 허브 경로 생성 API

### DIFF
--- a/msa.hub/src/main/java/com/msa/hub/application/service/HubRouteCreateService.java
+++ b/msa.hub/src/main/java/com/msa/hub/application/service/HubRouteCreateService.java
@@ -1,0 +1,103 @@
+package com.msa.hub.application.service;
+
+
+import com.msa.hub.domain.model.Hub;
+import com.msa.hub.domain.model.HubRoute;
+import com.msa.hub.domain.model.Waypoint;
+import com.msa.hub.domain.repository.HubRepository;
+import com.msa.hub.domain.repository.HubRouteRepository;
+import com.msa.hub.domain.service.DistanceCalculator;
+import com.msa.hub.domain.service.WaypointSelector;
+import com.msa.hub.exception.ErrorCode;
+import com.msa.hub.exception.HubException;
+import java.util.ArrayList;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class HubRouteCreateService {
+
+    private final HubRepository hubRepository;
+    private final HubRouteRepository routeRepository;
+    private final DistanceCalculator distanceCalculator;
+    private final WaypointSelector waypointSelector;
+
+    @Transactional
+    public void createRoute(final String sourceId, final String destinationId) {
+        Hub source = getHubOrException(sourceId);
+        Hub destination = getHubOrException(destinationId);
+
+        HubRoute route = initializeRoute(source, destination);
+
+        List<Hub> allHubs = hubRepository.findAll();
+        List<Waypoint> waypoints = createWaypoints(route, source, destination, allHubs);
+        route.updateWaypoints(waypoints);
+
+        routeRepository.save(route);
+    }
+
+    private Hub getHubOrException(final String id) {
+        return hubRepository.findById(id)
+                .orElseThrow(() -> new HubException(ErrorCode.HUB_NOT_FOUND));
+    }
+
+    private HubRoute initializeRoute(Hub source, Hub destination) {
+        double totalDistance = calculateDistance(source, destination);
+        long totalDuration = calculateDuration(totalDistance);
+
+        return HubRoute.createBy(
+                source,
+                destination,
+                totalDistance,
+                totalDuration
+        );
+    }
+
+    /*
+    중간 경유지 생성
+     */
+    private List<Waypoint> createWaypoints(HubRoute route, Hub source, Hub destination, List<Hub> allHubs) {
+        List<Hub> waypointsHubs = waypointSelector.findWaypoints(source, destination, allHubs);
+
+        List<Waypoint> waypoints = new ArrayList<>();
+        Hub current = source;
+
+        for (Hub waypointHub : waypointsHubs) {
+            Waypoint waypoint = createWaypoint(route, current, waypointHub);
+            waypoints.add(waypoint);
+            current = waypointHub;
+        }
+
+        // 마지막 허브까지의 경유지 추가
+        if (!waypointsHubs.isEmpty()) {
+            waypoints.add(createWaypoint(route, current, destination));
+        }
+
+        return waypoints;
+    }
+
+    private Waypoint createWaypoint(HubRoute route, Hub fromHub, Hub toHub) {
+        double distance = calculateDistance(fromHub, toHub);
+        int duration = calculateDuration(distance);
+        return Waypoint.createBy(
+                route,
+                toHub,
+                distance,
+                duration
+        );
+    }
+
+    private double calculateDistance(Hub from, Hub to) {
+        return distanceCalculator.calculateDistance(
+                from.getLatitude(), from.getLongitude(),
+                to.getLatitude(), to.getLongitude()
+        );
+    }
+
+    private int calculateDuration(double distance) {
+        return distanceCalculator.calculateDuration(distance);
+    }
+}

--- a/msa.hub/src/main/java/com/msa/hub/domain/model/HubRoute.java
+++ b/msa.hub/src/main/java/com/msa/hub/domain/model/HubRoute.java
@@ -52,4 +52,17 @@ public class HubRoute extends BaseEntity {
         this.distance = distance;
         this.duration = duration;
     }
+
+    public static HubRoute createBy(Hub sourceHubId, Hub destinationHubId, Double distance, Long duration) {
+        return HubRoute.builder()
+                .sourceHubId(sourceHubId)
+                .destinationHubId(destinationHubId)
+                .distance(distance)
+                .duration(duration)
+                .build();
+    }
+
+    public void updateWaypoints(List<Waypoint> waypoints) {
+        this.waypoints = waypoints;
+    }
 }

--- a/msa.hub/src/main/java/com/msa/hub/domain/model/HubRoute.java
+++ b/msa.hub/src/main/java/com/msa/hub/domain/model/HubRoute.java
@@ -1,6 +1,7 @@
 package com.msa.hub.domain.model;
 
 
+import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
@@ -9,7 +10,9 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
+import java.util.List;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -38,6 +41,9 @@ public class HubRoute extends BaseEntity {
 
     @Column(name="duration", nullable=false)
     private Long duration;
+
+    @OneToMany(mappedBy = "route", cascade = CascadeType.ALL)
+    private List<Waypoint> waypoints;
 
     @Builder(access = AccessLevel.PRIVATE)
     private HubRoute(Hub sourceHubId, Hub destinationHubId, Double distance, Long duration) {

--- a/msa.hub/src/main/java/com/msa/hub/domain/model/Waypoint.java
+++ b/msa.hub/src/main/java/com/msa/hub/domain/model/Waypoint.java
@@ -1,0 +1,56 @@
+package com.msa.hub.domain.model;
+
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Entity
+@Table(name = "p_hub_route_way_point")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Waypoint {
+    @Id
+    @GeneratedValue(strategy= GenerationType.UUID)
+    @Column(name="id")
+    private String id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    private HubRoute linkedRoute;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    private Hub hub;
+
+    @Column(name="distance_from_previous", nullable=false)
+    private double distanceFromPrevious;
+
+    @Column(name="duration_from_previuos", nullable=false)
+    private int durationFromPrevious;
+
+    @Builder(access = AccessLevel.PRIVATE)
+    private Waypoint(HubRoute linkedRoute, Hub hub, double distanceFromPrevious, int durationFromPrevious) {
+        this.linkedRoute = linkedRoute;
+        this.hub = hub;
+        this.distanceFromPrevious = distanceFromPrevious;
+        this.durationFromPrevious = durationFromPrevious;
+    }
+
+    public static Waypoint createBy(HubRoute route, Hub hub, double distanceFromPrevious, int durationFromPrevious) {
+        return Waypoint.builder()
+                .linkedRoute(route)
+                .hub(hub)
+                .distanceFromPrevious(distanceFromPrevious)
+                .durationFromPrevious(durationFromPrevious)
+                .build();
+    }
+
+}

--- a/msa.hub/src/main/java/com/msa/hub/domain/repository/HubRouteRepository.java
+++ b/msa.hub/src/main/java/com/msa/hub/domain/repository/HubRouteRepository.java
@@ -1,0 +1,10 @@
+package com.msa.hub.domain.repository;
+
+
+import com.msa.hub.domain.model.HubRoute;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface HubRouteRepository extends JpaRepository<HubRoute, String> {
+}

--- a/msa.hub/src/main/java/com/msa/hub/domain/service/DistanceCalculator.java
+++ b/msa.hub/src/main/java/com/msa/hub/domain/service/DistanceCalculator.java
@@ -1,0 +1,31 @@
+package com.msa.hub.domain.service;
+
+
+import org.springframework.stereotype.Component;
+
+/**
+ * 위도 경도 정보로 거리 계산
+ */
+@Component
+public class DistanceCalculator {
+
+    private static final double EARTH_RADIUS = 6371;
+
+    public double calculateDistance(double lat1, double lon1, double lat2, double lon2) {
+        double dLat = Math.toRadians(lat2 - lat1);
+        double dLon = Math.toRadians(lon2 - lon1);
+
+        double a = Math.sin(dLat / 2) * Math.sin(dLat / 2)
+                + Math.cos(Math.toRadians(lat1)) * Math.cos(Math.toRadians(lat2))
+                * Math.sin(dLon / 2) * Math.sin(dLon / 2);
+
+        double c = 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a));
+        return EARTH_RADIUS * c;
+    }
+
+    public int calculateDuration(double distance) {
+        final int AVERAGE_SPEED_KMH = 60;
+        return (int) (distance / AVERAGE_SPEED_KMH * 60);
+    }
+
+}

--- a/msa.hub/src/main/java/com/msa/hub/domain/service/WaypointSelector.java
+++ b/msa.hub/src/main/java/com/msa/hub/domain/service/WaypointSelector.java
@@ -1,0 +1,52 @@
+package com.msa.hub.domain.service;
+
+
+import com.msa.hub.domain.model.Hub;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import org.springframework.stereotype.Component;
+
+
+@Component
+public class WaypointSelector {
+
+    public List<Hub> findWaypoints(Hub source, Hub destination, List<Hub> hubs) {
+        List<Hub> remainingHubs = new ArrayList<>(hubs);
+        remainingHubs.remove(source);
+        remainingHubs.remove(destination);
+
+        List<Hub> waypoints = new ArrayList<>();
+        Hub current = source;
+
+        while (true) {
+            double distanceToDestination = calculateDistance(
+                    current.getLatitude(), current.getLongitude(),
+                    destination.getLatitude(), destination.getLongitude()
+            );
+            if (distanceToDestination <= 200) {
+                break;
+            }
+            Hub finalCurrent = current;
+            Hub nextWaypoint = remainingHubs.stream()
+                    .min(Comparator.comparingDouble(hub ->
+                            calculateDistance(
+                                    finalCurrent.getLatitude(), finalCurrent.getLongitude(),
+                                    hub.getLatitude(), hub.getLongitude())))
+                    .orElse(null);
+            if (nextWaypoint == null) {
+                break;
+            }
+
+            waypoints.add(nextWaypoint);
+            remainingHubs.remove(nextWaypoint);
+            current = nextWaypoint;
+        }
+        return waypoints;
+    }
+
+
+    private double calculateDistance(double lat1, double lon1, double lat2, double lon2) {
+        return new DistanceCalculator().calculateDistance(lat1, lon1, lat2, lon2);
+    }
+}

--- a/msa.hub/src/main/java/com/msa/hub/exception/ErrorCode.java
+++ b/msa.hub/src/main/java/com/msa/hub/exception/ErrorCode.java
@@ -7,7 +7,8 @@ import org.springframework.http.HttpStatus;
 @Getter
 @AllArgsConstructor
 public enum ErrorCode {
-    DUPLICATE_HUB_NAME(HttpStatus.BAD_REQUEST, "이미 존재하는 허브입니다.");
+    DUPLICATE_HUB_NAME(HttpStatus.BAD_REQUEST, "이미 존재하는 허브입니다."),
+    HUB_NOT_FOUND(HttpStatus.NOT_FOUND, "일치하는 허브 정보를 찾을 수 없습니다.");
     private final HttpStatus httpStatus;
     private final String message;
 }

--- a/msa.hub/src/main/java/com/msa/hub/presentation/controller/HubRouteController.java
+++ b/msa.hub/src/main/java/com/msa/hub/presentation/controller/HubRouteController.java
@@ -1,0 +1,30 @@
+package com.msa.hub.presentation.controller;
+
+
+import com.msa.hub.application.service.HubRouteCreateService;
+import com.msa.hub.presentation.request.HubRouteCreateRequest;
+import com.msa.hub.presentation.response.ApiResponse;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("hub-routes")
+public class HubRouteController {
+
+    private final HubRouteCreateService hubRouteCreateService;
+
+    @PostMapping
+    @PreAuthorize("hasAuthority('MASTER')")
+    public ApiResponse<Void> postHubRoute(
+            @Valid @RequestBody HubRouteCreateRequest request
+    ) {
+        hubRouteCreateService.createRoute(request.sourceHubId(), request.destinationHubId());
+        return ApiResponse.success();
+    }
+}

--- a/msa.hub/src/main/java/com/msa/hub/presentation/request/HubRouteCreateRequest.java
+++ b/msa.hub/src/main/java/com/msa/hub/presentation/request/HubRouteCreateRequest.java
@@ -1,0 +1,9 @@
+package com.msa.hub.presentation.request;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record HubRouteCreateRequest(
+        @NotBlank String sourceHubId,
+        @NotBlank String destinationHubId
+) {
+}


### PR DESCRIPTION
## Summary
<!-- 해당 PR에 어떤 작업이 포함됐는지 요약해주세요 -->
<!-- merge시 관련 이슈가 자동으로 close 되도록 이슈 번호를 작성해주세요 -->
- closed #31 -> main

허브 경로를 생성하는 API 를 개발했습니다.
따로 요청으로 경로를 적지 않고 내부 알고리즘을 통해 자동으로 계산되도록 구현했습니다.
경유지 선정은 다음 P2P + Hub to Hub Relay 방법을 채택했습니다.

![image](https://github.com/user-attachments/assets/81c96bb6-d8e0-4630-adaa-e0b308b85fc6)
- 기본적으로 인접한 허브로 직접 배송할 수 있습니다.
- 배송거리가 200km 이상인 경우 중간 경유지를 생성합니다.
- 출발지와 거리가 가까운 허브를 중간 경유지로 선택합니다.

## Key Changes
<!-- 주요 변경 사항을 기재해주세요 -->
- 경유지 엔티티 추가
- 도메인쪽에 거리 계산, 경유지 계산 클래스 생성


## Testing
<!-- 해당 작업이 성공된 것을 확인할 수 있는 방법을 기재해주세요 -->
<!-- 전/후 스크린샷을 첨부하기도 합니다 -->
**성공**

![image](https://github.com/user-attachments/assets/e6d58b13-096d-40cf-a52c-a87b78a1ede0)
 
DB 에 저장되는 것을 확인했습니다.


## To Reviewers
<!-- 리뷰어에게 전달하거나 논의하고 싶은 내용을 기재해주세요 -->
- 위도, 경도 거리 계산은 다음 사이트를 사용했습니다. https://deveapp.com/map.php
- 허브 정보가 기본적으로 생성되어 있어야 사용이 가능할 것 같은데 빠른 시일 내에 더미 데이터를 위한 sql 파일을 추가하도록 하겠습니다! 🙇‍♀️
- 기타 궁금하신 점, 개선할 점 등 생각나시는 의견 있으시면 편하게 남겨주세요!