### PR TITLE
[Fix] 허브 생성 시 관리자 정보도 함께 저장되도록 수정

### DIFF
--- a/msa.hub/src/main/java/com/msa/hub/application/dto/Role.java
+++ b/msa.hub/src/main/java/com/msa/hub/application/dto/Role.java
@@ -1,0 +1,13 @@
+package com.msa.hub.application.dto;
+
+import lombok.AllArgsConstructor;
+
+@AllArgsConstructor
+public enum Role {
+    MASTER("마스터 관리자"),
+    HUB_MANAGER("허브 관리자"),
+    COMPANY_MANAGER("업체 담당자"),
+    DELIVERY_MANAGER("배송 담당자");
+
+    private final String description;
+}

--- a/msa.hub/src/main/java/com/msa/hub/application/dto/UserDetailResponse.java
+++ b/msa.hub/src/main/java/com/msa/hub/application/dto/UserDetailResponse.java
@@ -1,0 +1,14 @@
+package com.msa.hub.application.dto;
+
+import java.time.LocalDateTime;
+
+public record UserDetailResponse(
+        Long id,
+        String username,
+        String email,
+        String slackId,
+        Role role,
+        LocalDateTime createAt,
+        LocalDateTime updatedAt
+) {
+}

--- a/msa.hub/src/main/java/com/msa/hub/application/service/HubService.java
+++ b/msa.hub/src/main/java/com/msa/hub/application/service/HubService.java
@@ -1,6 +1,7 @@
 package com.msa.hub.application.service;
 
 
+import com.msa.hub.application.dto.Role;
 import com.msa.hub.domain.model.Hub;
 import com.msa.hub.domain.repository.HubRepository;
 import com.msa.hub.exception.ErrorCode;
@@ -15,6 +16,7 @@ import org.springframework.transaction.annotation.Transactional;
 @Transactional(readOnly = true)
 public class HubService {
 
+    private final UserService userService;
     private final HubRepository hubRepository;
 
     @Transactional
@@ -22,6 +24,14 @@ public class HubService {
         if(existsHub(request.name())) {
             throw new HubException(ErrorCode.DUPLICATE_HUB_NAME);
         }
+        Role managerRole = userService
+                .findUser(request.managerId())
+                .data().role();
+
+        if(managerRole!=Role.HUB_MANAGER) {
+            throw new HubException(ErrorCode.INVALID_ROLE);
+        }
+
         hubRepository.save(
                 Hub.createBy(
                         request.name(),

--- a/msa.hub/src/main/java/com/msa/hub/application/service/HubService.java
+++ b/msa.hub/src/main/java/com/msa/hub/application/service/HubService.java
@@ -31,7 +31,8 @@ public class HubService {
                         request.streetNumber(),
                         request.addressDetail(),
                         request.latitude(),
-                        request.longitude()
+                        request.longitude(),
+                        request.managerId()
                 )
         );
     }

--- a/msa.hub/src/main/java/com/msa/hub/application/service/UserService.java
+++ b/msa.hub/src/main/java/com/msa/hub/application/service/UserService.java
@@ -1,0 +1,9 @@
+package com.msa.hub.application.service;
+
+import com.msa.hub.application.dto.UserDetailResponse;
+import com.msa.hub.presentation.response.ApiResponse;
+import org.springframework.web.bind.annotation.PathVariable;
+
+public interface UserService {
+    ApiResponse<UserDetailResponse> findUser(@PathVariable Long userId);
+}

--- a/msa.hub/src/main/java/com/msa/hub/domain/model/Hub.java
+++ b/msa.hub/src/main/java/com/msa/hub/domain/model/Hub.java
@@ -53,6 +53,9 @@ public class Hub extends BaseEntity {
     @Column(name="longitude", nullable=false)
     private Double longitude;
 
+    @Column(name="manager_id", nullable = false)
+    private Long managerId;
+
     @OneToMany(mappedBy = "sourceHubId")
     private List<HubRoute> sourceHubRoutes = new ArrayList<>();
 
@@ -61,7 +64,7 @@ public class Hub extends BaseEntity {
 
     @Builder(access = AccessLevel.PRIVATE)
     private Hub(String name, String city, String district, String streetName, String streetNumber, String addressDetail,
-               Double latitude, Double longitude) {
+               Double latitude, Double longitude, Long managerId) {
         this.name = name;
         this.city = city;
         this.district = district;
@@ -70,11 +73,12 @@ public class Hub extends BaseEntity {
         this.addressDetail = addressDetail;
         this.latitude = latitude;
         this.longitude = longitude;
+        this.managerId = managerId;
     }
 
     public static Hub createBy(String name, String city,
                              String district, String streetName, String streetNumber, String addressDetail,
-                             Double latitude, Double longitude) {
+                             Double latitude, Double longitude, Long managerId) {
         return Hub.builder()
                 .name(name)
                 .city(city)
@@ -84,6 +88,7 @@ public class Hub extends BaseEntity {
                 .addressDetail(addressDetail)
                 .latitude(latitude)
                 .longitude(longitude)
+                .managerId(managerId)
                 .build();
     }
 

--- a/msa.hub/src/main/java/com/msa/hub/domain/model/HubRoute.java
+++ b/msa.hub/src/main/java/com/msa/hub/domain/model/HubRoute.java
@@ -42,7 +42,7 @@ public class HubRoute extends BaseEntity {
     @Column(name="duration", nullable=false)
     private Long duration;
 
-    @OneToMany(mappedBy = "route", cascade = CascadeType.ALL)
+    @OneToMany(mappedBy = "linkedRoute", cascade = CascadeType.ALL)
     private List<Waypoint> waypoints;
 
     @Builder(access = AccessLevel.PRIVATE)

--- a/msa.hub/src/main/java/com/msa/hub/exception/ErrorCode.java
+++ b/msa.hub/src/main/java/com/msa/hub/exception/ErrorCode.java
@@ -7,6 +7,7 @@ import org.springframework.http.HttpStatus;
 @Getter
 @AllArgsConstructor
 public enum ErrorCode {
+    INVALID_ROLE(HttpStatus.UNAUTHORIZED, "허브 관리자 권한이 존재하지 않습니다."),
     DUPLICATE_HUB_NAME(HttpStatus.BAD_REQUEST, "이미 존재하는 허브입니다."),
     HUB_NOT_FOUND(HttpStatus.NOT_FOUND, "일치하는 허브 정보를 찾을 수 없습니다.");
     private final HttpStatus httpStatus;

--- a/msa.hub/src/main/java/com/msa/hub/infrastructure/UserClient.java
+++ b/msa.hub/src/main/java/com/msa/hub/infrastructure/UserClient.java
@@ -1,0 +1,15 @@
+package com.msa.hub.infrastructure;
+
+
+import com.msa.hub.application.dto.UserDetailResponse;
+import com.msa.hub.application.service.UserService;
+import com.msa.hub.presentation.response.ApiResponse;
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+
+@FeignClient(name = "user-service")
+public interface UserClient extends UserService {
+    @GetMapping("/users/{userId}")
+    ApiResponse<UserDetailResponse> findUser(@PathVariable Long userId);
+}

--- a/msa.hub/src/main/java/com/msa/hub/infrastructure/config/FeignConfig.java
+++ b/msa.hub/src/main/java/com/msa/hub/infrastructure/config/FeignConfig.java
@@ -1,0 +1,26 @@
+package com.msa.hub.infrastructure.config;
+
+
+import feign.RequestInterceptor;
+import jakarta.servlet.http.HttpServletRequest;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.context.request.RequestContextHolder;
+import org.springframework.web.context.request.ServletRequestAttributes;
+
+@Configuration
+public class FeignConfig {
+    @Bean
+    public RequestInterceptor requestInterceptor() {
+        return requestTemplate -> {
+            ServletRequestAttributes attributes = (ServletRequestAttributes) RequestContextHolder.getRequestAttributes();
+            if (attributes != null) {
+                HttpServletRequest request = attributes.getRequest();
+                final String id = request.getHeader("X-User-Id");
+                final String role = request.getHeader("X-User-Role");
+                requestTemplate.header("X-User-Id", id);
+                requestTemplate.header("X-User-Role", role);
+            }
+        };
+    }
+}

--- a/msa.hub/src/main/java/com/msa/hub/presentation/request/HubCreateRequest.java
+++ b/msa.hub/src/main/java/com/msa/hub/presentation/request/HubCreateRequest.java
@@ -11,6 +11,7 @@ public record HubCreateRequest(
         @NotBlank String streetNumber,
         @NotBlank String addressDetail,
         @NotNull Double latitude,
-        @NotNull Double longitude
+        @NotNull Double longitude,
+        @NotNull Long managerId
 ) {
 }

--- a/msa.user/src/main/java/com/msa/user/presentation/controller/UserController.java
+++ b/msa.user/src/main/java/com/msa/user/presentation/controller/UserController.java
@@ -16,11 +16,11 @@ public class UserController {
 
     private final UserService userService;
 
-    @GetMapping("/{user_id}")
+    @GetMapping("/{userId}")
     public ApiResponse<UserDetailResponse> findUser(
-            @PathVariable Long user_id
+            @PathVariable Long userId
     ) {
-        return ApiResponse.success(userService.getUser(user_id));
+        return ApiResponse.success(userService.getUser(userId));
     }
 
 }


### PR DESCRIPTION
## Summary
<!-- 해당 PR에 어떤 작업이 포함됐는지 요약해주세요 -->
<!-- merge시 관련 이슈가 자동으로 close 되도록 이슈 번호를 작성해주세요 -->
- closed #39 -> main

허브 엔티티에 관리자 정보(user id)가 들어가도록 수정했습니다.
기존 허브 생성 기능에  매니저 id를 받고 해당 유저의 권한이 허브 관리자인지 확인하는 과정을 거치도록 수정했습니다.

## Key Changes
<!-- 주요 변경 사항을 기재해주세요 -->
- 유저 서비스와 연결
- 허브 엔티티에 관리자 아이디 필드 추가
- 권한 없는 경우의 에러 코드 수정

## Testing
<!-- 해당 작업이 성공된 것을 확인할 수 있는 방법을 기재해주세요 -->
<!-- 전/후 스크린샷을 첨부하기도 합니다 -->
- 요청으로 받은 매니저 id 유저의 role이 허브 관리자가 아닌 경우 생성되지 않습니다.
![image](https://github.com/user-attachments/assets/3eb3ee2e-c4e4-41c6-adc0-ace5ff83e416)

- 권한이 허브 관리자인 유저의 id를 요청으로 넘기면 정상적으로 생성됩니다.
![image](https://github.com/user-attachments/assets/68f4fe35-ba53-41bd-a000-8da35102d0c1)


## To Reviewers
<!-- 리뷰어에게 전달하거나 논의하고 싶은 내용을 기재해주세요 -->
- 빨리 해결해야 될 것 같아서 콜백 에러 처리 등은 추가하지 않았는데 해당 부분은 추후에 따로 추가하도록 하겠습니다!
- 에러 메세지도 사실 조금 애매하다고 생각되는데 관련해서 좋은 의견 있으시면 말씀해주시면 감사하겠습니다!
- 기타 궁금하신 점, 개선할 점 등 생각나시는 의견 있으시면 편하게 남겨주세요!