### PR TITLE
[Feat] 허브 경로 조회 및 검색 API

### DIFF
--- a/msa.hub/build.gradle
+++ b/msa.hub/build.gradle
@@ -44,6 +44,13 @@ dependencies {
 	// jpa
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 
+	// querydsl
+	implementation "com.querydsl:querydsl-jpa:5.0.0:jakarta"
+	annotationProcessor "com.querydsl:querydsl-apt:5.0.0:jakarta"
+	annotationProcessor "jakarta.annotation:jakarta.annotation-api"
+	annotationProcessor "jakarta.persistence:jakarta.persistence-api"
+	implementation 'org.jetbrains:annotations:24.1.0'
+
 	compileOnly 'org.projectlombok:lombok'
 	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'

--- a/msa.hub/src/main/java/com/msa/hub/application/dto/HubRouteDetailResponse.java
+++ b/msa.hub/src/main/java/com/msa/hub/application/dto/HubRouteDetailResponse.java
@@ -1,0 +1,46 @@
+package com.msa.hub.application.dto;
+
+import com.msa.hub.domain.model.HubRoute;
+import com.msa.hub.domain.model.Waypoint;
+import java.time.LocalDateTime;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Optional;
+
+public record HubRouteDetailResponse(
+        String hubRouteId,
+        String sourceHubId,
+        String sourceHubName,
+        String destinationHubId,
+        String destinationHubName,
+        Double totalDistance,
+        Long totalDuration,
+        List<WayPointResponse> waypoints,
+        LocalDateTime createdAt,
+        LocalDateTime updatedAt
+
+) {
+    public static HubRouteDetailResponse convertToResponse(HubRoute hubRoute) {
+        return new HubRouteDetailResponse(
+                hubRoute.getId(),
+                hubRoute.getSourceHub().getId(),
+                hubRoute.getSourceHub().getName(),
+                hubRoute.getDestinationHub().getId(),
+                hubRoute.getDestinationHub().getName(),
+                hubRoute.getTotalDistance(),
+                hubRoute.getTotalDuration(),
+                convert(hubRoute.getWaypoints()),
+                hubRoute.getCreatedAt(),
+                hubRoute.getUpdatedAt()
+        );
+    }
+
+    private static List<WayPointResponse> convert(List<Waypoint> waypoints) {
+        return Optional.ofNullable(waypoints)
+                .orElse(List.of())
+                .stream()
+                .sorted(Comparator.comparingInt(Waypoint::getSequence))
+                .map(WayPointResponse::fromEntity)
+                .toList();
+    }
+}

--- a/msa.hub/src/main/java/com/msa/hub/application/dto/HubRouteResponse.java
+++ b/msa.hub/src/main/java/com/msa/hub/application/dto/HubRouteResponse.java
@@ -1,0 +1,30 @@
+package com.msa.hub.application.dto;
+
+import com.msa.hub.domain.model.HubRoute;
+import java.time.LocalDateTime;
+
+public record HubRouteResponse(
+        String hubRouteId,
+        String sourceHubId,
+        String sourceHubName,
+        String destinationHubId,
+        String destinationHubName,
+        Double totalDistance,
+        Long totalDuration,
+        LocalDateTime createdAt,
+        LocalDateTime updatedAt
+) {
+    public static HubRouteResponse convertToResponse(HubRoute hubRoute) {
+        return new HubRouteResponse(
+                hubRoute.getId(),
+                hubRoute.getSourceHub().getId(),
+                hubRoute.getSourceHub().getName(),
+                hubRoute.getDestinationHub().getId(),
+                hubRoute.getDestinationHub().getName(),
+                hubRoute.getTotalDistance(),
+                hubRoute.getTotalDuration(),
+                hubRoute.getCreatedAt(),
+                hubRoute.getUpdatedAt()
+        );
+    }
+}

--- a/msa.hub/src/main/java/com/msa/hub/application/dto/WayPointResponse.java
+++ b/msa.hub/src/main/java/com/msa/hub/application/dto/WayPointResponse.java
@@ -1,0 +1,23 @@
+package com.msa.hub.application.dto;
+
+import com.msa.hub.domain.model.Waypoint;
+
+public record WayPointResponse(
+        String waypointId,
+        String hubId,
+        String hubName,
+        double distanceFromPrevious,
+        int durationFromPrevious,
+        int order
+) {
+    public static WayPointResponse fromEntity(Waypoint waypoint) {
+        return new WayPointResponse(
+                waypoint.getId(),
+                waypoint.getHub().getId(),
+                waypoint.getHub().getName(),
+                waypoint.getDistanceFromPrevious(),
+                waypoint.getDurationFromPrevious(),
+                waypoint.getSequence()
+        );
+    }
+}

--- a/msa.hub/src/main/java/com/msa/hub/application/service/HubRouteCreateService.java
+++ b/msa.hub/src/main/java/com/msa/hub/application/service/HubRouteCreateService.java
@@ -65,28 +65,31 @@ public class HubRouteCreateService {
         List<Waypoint> waypoints = new ArrayList<>();
         Hub current = source;
 
+        int sequence = 1;
         for (Hub waypointHub : waypointsHubs) {
-            Waypoint waypoint = createWaypoint(route, current, waypointHub);
+            Waypoint waypoint = createWaypoint(route, current, waypointHub, sequence);
             waypoints.add(waypoint);
             current = waypointHub;
+            sequence++;
         }
 
         // 마지막 허브까지의 경유지 추가
         if (!waypointsHubs.isEmpty()) {
-            waypoints.add(createWaypoint(route, current, destination));
+            waypoints.add(createWaypoint(route, current, destination, sequence));
         }
 
         return waypoints;
     }
 
-    private Waypoint createWaypoint(HubRoute route, Hub fromHub, Hub toHub) {
+    private Waypoint createWaypoint(HubRoute route, Hub fromHub, Hub toHub, int sequence) {
         double distance = calculateDistance(fromHub, toHub);
         int duration = calculateDuration(distance);
         return Waypoint.createBy(
                 route,
                 toHub,
                 distance,
-                duration
+                duration,
+                sequence
         );
     }
 

--- a/msa.hub/src/main/java/com/msa/hub/application/service/HubRouteReadService.java
+++ b/msa.hub/src/main/java/com/msa/hub/application/service/HubRouteReadService.java
@@ -1,0 +1,44 @@
+package com.msa.hub.application.service;
+
+
+import com.msa.hub.application.dto.HubRouteDetailResponse;
+import com.msa.hub.application.dto.HubRouteResponse;
+import com.msa.hub.domain.repository.HubRouteRepository;
+import com.msa.hub.exception.ErrorCode;
+import com.msa.hub.exception.HubException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class HubRouteReadService {
+
+    private final HubRouteRepository hubRouteRepository;
+
+    public HubRouteDetailResponse getHubRouteDetail(String id) {
+        return HubRouteDetailResponse.convertToResponse(
+                hubRouteRepository.findById(id)
+                        .orElseThrow(()-> new HubException(ErrorCode.HUB_ROUTE_NOT_FOUND))
+        );
+    }
+
+    public Page<HubRouteResponse> findHubRoutes(
+            Pageable pageable, String sourceHubId, String destinationHubId
+    ) {
+        return hubRouteRepository
+                .findHubRoutesWith(pageable, sourceHubId, destinationHubId)
+                .map(HubRouteResponse::convertToResponse);
+    }
+
+    public HubRouteDetailResponse findHubRouteBy(String sourceHubId, String destinationHubId) {
+        return HubRouteDetailResponse.convertToResponse(
+                hubRouteRepository.findBySourceHubIdAndDestinationHubId(sourceHubId, destinationHubId)
+                        .orElseThrow(()-> new HubException(ErrorCode.HUB_ROUTE_NOT_FOUND))
+        );
+    }
+
+}

--- a/msa.hub/src/main/java/com/msa/hub/domain/config/QueryDslConfig.java
+++ b/msa.hub/src/main/java/com/msa/hub/domain/config/QueryDslConfig.java
@@ -1,0 +1,19 @@
+package com.msa.hub.domain.config;
+
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@RequiredArgsConstructor
+public class QueryDslConfig {
+    private final EntityManager entityManager;
+
+    @Bean
+    public JPAQueryFactory jPAQueryFactory() {
+        return new JPAQueryFactory(entityManager);
+    }
+}

--- a/msa.hub/src/main/java/com/msa/hub/domain/model/Hub.java
+++ b/msa.hub/src/main/java/com/msa/hub/domain/model/Hub.java
@@ -56,10 +56,10 @@ public class Hub extends BaseEntity {
     @Column(name="manager_id", nullable = false)
     private Long managerId;
 
-    @OneToMany(mappedBy = "sourceHubId")
+    @OneToMany(mappedBy = "sourceHub")
     private List<HubRoute> sourceHubRoutes = new ArrayList<>();
 
-    @OneToMany(mappedBy = "destinationHubId")
+    @OneToMany(mappedBy = "destinationHub")
     private List<HubRoute> destinationHubRoutes = new ArrayList<>();
 
     @Builder(access = AccessLevel.PRIVATE)

--- a/msa.hub/src/main/java/com/msa/hub/domain/model/HubRoute.java
+++ b/msa.hub/src/main/java/com/msa/hub/domain/model/HubRoute.java
@@ -30,35 +30,35 @@ public class HubRoute extends BaseEntity {
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "source_hub_id")
-    private Hub sourceHubId;
+    private Hub sourceHub;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "destination_hub_id")
-    private Hub destinationHubId;
+    private Hub destinationHub;
 
     @Column(name="distance", nullable=false)
-    private Double distance;
+    private Double totalDistance;
 
     @Column(name="duration", nullable=false)
-    private Long duration;
+    private Long totalDuration;
 
     @OneToMany(mappedBy = "linkedRoute", cascade = CascadeType.ALL)
     private List<Waypoint> waypoints;
 
     @Builder(access = AccessLevel.PRIVATE)
-    private HubRoute(Hub sourceHubId, Hub destinationHubId, Double distance, Long duration) {
-        this.sourceHubId = sourceHubId;
-        this.destinationHubId = destinationHubId;
-        this.distance = distance;
-        this.duration = duration;
+    private HubRoute(Hub sourceHub, Hub destinationHub, Double totalDistance, Long totalDuration) {
+        this.sourceHub = sourceHub;
+        this.destinationHub = destinationHub;
+        this.totalDistance = totalDistance;
+        this.totalDuration = totalDuration;
     }
 
-    public static HubRoute createBy(Hub sourceHubId, Hub destinationHubId, Double distance, Long duration) {
+    public static HubRoute createBy(Hub sourceHub, Hub destinationHub, Double totalDistance, Long totalDuration) {
         return HubRoute.builder()
-                .sourceHubId(sourceHubId)
-                .destinationHubId(destinationHubId)
-                .distance(distance)
-                .duration(duration)
+                .sourceHub(sourceHub)
+                .destinationHub(destinationHub)
+                .totalDistance(totalDistance)
+                .totalDuration(totalDuration)
                 .build();
     }
 

--- a/msa.hub/src/main/java/com/msa/hub/domain/model/Waypoint.java
+++ b/msa.hub/src/main/java/com/msa/hub/domain/model/Waypoint.java
@@ -36,20 +36,25 @@ public class Waypoint {
     @Column(name="duration_from_previuos", nullable=false)
     private int durationFromPrevious;
 
+    @Column(name="sequence", nullable=false)
+    private int sequence;
+
     @Builder(access = AccessLevel.PRIVATE)
-    private Waypoint(HubRoute linkedRoute, Hub hub, double distanceFromPrevious, int durationFromPrevious) {
+    private Waypoint(HubRoute linkedRoute, Hub hub, double distanceFromPrevious, int durationFromPrevious, int sequence) {
         this.linkedRoute = linkedRoute;
         this.hub = hub;
         this.distanceFromPrevious = distanceFromPrevious;
         this.durationFromPrevious = durationFromPrevious;
+        this.sequence = sequence;
     }
 
-    public static Waypoint createBy(HubRoute route, Hub hub, double distanceFromPrevious, int durationFromPrevious) {
+    public static Waypoint createBy(HubRoute route, Hub hub, double distanceFromPrevious, int durationFromPrevious, int sequence) {
         return Waypoint.builder()
                 .linkedRoute(route)
                 .hub(hub)
                 .distanceFromPrevious(distanceFromPrevious)
                 .durationFromPrevious(durationFromPrevious)
+                .sequence(sequence)
                 .build();
     }
 

--- a/msa.hub/src/main/java/com/msa/hub/domain/repository/HubRouteCustomRepository.java
+++ b/msa.hub/src/main/java/com/msa/hub/domain/repository/HubRouteCustomRepository.java
@@ -1,0 +1,9 @@
+package com.msa.hub.domain.repository;
+
+import com.msa.hub.domain.model.HubRoute;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+public interface HubRouteCustomRepository {
+    Page<HubRoute> findHubRoutesWith(Pageable pageable, String sourceHubId, String destinationHubId);
+}

--- a/msa.hub/src/main/java/com/msa/hub/domain/repository/HubRouteCustomRepositoryImpl.java
+++ b/msa.hub/src/main/java/com/msa/hub/domain/repository/HubRouteCustomRepositoryImpl.java
@@ -27,10 +27,7 @@ import org.springframework.stereotype.Repository;
 public class HubRouteCustomRepositoryImpl implements HubRouteCustomRepository {
 
     private final JPAQueryFactory queryFactory;
-
-
-
-
+    
     @Override
     public Page<HubRoute> findHubRoutesWith(
             Pageable pageable, String sourceHubId, String destinationHubId

--- a/msa.hub/src/main/java/com/msa/hub/domain/repository/HubRouteCustomRepositoryImpl.java
+++ b/msa.hub/src/main/java/com/msa/hub/domain/repository/HubRouteCustomRepositoryImpl.java
@@ -1,0 +1,92 @@
+package com.msa.hub.domain.repository;
+
+
+
+
+
+import static com.msa.hub.domain.model.QHubRoute.hubRoute;
+
+import com.msa.hub.domain.model.HubRoute;
+import com.msa.hub.exception.ErrorCode;
+import com.msa.hub.exception.HubException;
+import com.querydsl.core.BooleanBuilder;
+import com.querydsl.core.types.OrderSpecifier;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.core.types.dsl.ComparableExpressionBase;
+import com.querydsl.jpa.impl.JPAQuery;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.support.PageableExecutionUtils;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class HubRouteCustomRepositoryImpl implements HubRouteCustomRepository {
+
+    private final JPAQueryFactory queryFactory;
+
+
+
+
+    @Override
+    public Page<HubRoute> findHubRoutesWith(
+            Pageable pageable, String sourceHubId, String destinationHubId
+    ) {
+        BooleanBuilder booleanBuilder = toBooleanBuilder(sourceHubId, destinationHubId);
+        List<HubRoute> result = queryFactory.selectFrom(hubRoute)
+                .where(booleanBuilder)
+                .orderBy(getOrderSpecifiers(pageable))
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize())
+                .fetch();
+        JPAQuery<Long> count = queryFactory.select(hubRoute.count())
+                .from(hubRoute)
+                .where(booleanBuilder);
+        return PageableExecutionUtils.getPage(result, pageable, count::fetchOne);
+
+    }
+
+    private BooleanBuilder toBooleanBuilder(String sourceHubId, String destinationHubId) {
+        BooleanBuilder builder = new BooleanBuilder();
+        builder.and(eqDestinationHub(destinationHubId));
+        builder.and(eqSourceHub(sourceHubId));
+        //builder.and(hubRoute.isDeleted.eq(false));
+        return builder;
+    }
+
+    private BooleanExpression eqSourceHub(String sourceHubId) {
+        return sourceHubId != null ? hubRoute.sourceHub.id.eq(sourceHubId) : null;
+    }
+
+    private BooleanExpression eqDestinationHub(String destinationHubId) {
+        return destinationHubId != null ? hubRoute.destinationHub.id.eq(destinationHubId) : null;
+    }
+
+    private OrderSpecifier<?>[] getOrderSpecifiers(Pageable pageable) {
+        return pageable.getSort().stream()
+                .map(order -> {
+                    ComparableExpressionBase<?> sortPath = getSortPath(order.getProperty());
+                    return new OrderSpecifier<>(
+                            order.isAscending()
+                                    ? com.querydsl.core.types.Order.ASC
+                                    : com.querydsl.core.types.Order.DESC,
+                            sortPath);
+                })
+                .toArray(OrderSpecifier[]::new);
+    }
+
+    /*
+    HubRoute 정렬 기준 저장
+     */
+    private ComparableExpressionBase<?> getSortPath(String property) {
+        return switch (property) {
+            case "createdAt" -> hubRoute.createdAt;
+            case "updatedAt" -> hubRoute.updatedAt;
+            default -> throw new HubException(ErrorCode.UNSUPPORTED_SORT_TYPE);
+        };
+    }
+
+}

--- a/msa.hub/src/main/java/com/msa/hub/domain/repository/HubRouteRepository.java
+++ b/msa.hub/src/main/java/com/msa/hub/domain/repository/HubRouteRepository.java
@@ -2,9 +2,11 @@ package com.msa.hub.domain.repository;
 
 
 import com.msa.hub.domain.model.HubRoute;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
-public interface HubRouteRepository extends JpaRepository<HubRoute, String> {
+public interface HubRouteRepository extends JpaRepository<HubRoute, String>, HubRouteCustomRepository{
+    Optional<HubRoute> findBySourceHubIdAndDestinationHubId(String sourceHubId, String destinationHubId);
 }

--- a/msa.hub/src/main/java/com/msa/hub/exception/ErrorCode.java
+++ b/msa.hub/src/main/java/com/msa/hub/exception/ErrorCode.java
@@ -7,6 +7,7 @@ import org.springframework.http.HttpStatus;
 @Getter
 @AllArgsConstructor
 public enum ErrorCode {
+    UNSUPPORTED_SORT_TYPE(HttpStatus.BAD_REQUEST, "지원하지 않는 정렬 방식입니다."),
     INVALID_ROLE(HttpStatus.UNAUTHORIZED, "허브 관리자 권한이 존재하지 않습니다."),
     DUPLICATE_HUB_NAME(HttpStatus.BAD_REQUEST, "이미 존재하는 허브입니다."),
     HUB_NOT_FOUND(HttpStatus.NOT_FOUND, "일치하는 허브 정보를 찾을 수 없습니다.");

--- a/msa.hub/src/main/java/com/msa/hub/exception/ErrorCode.java
+++ b/msa.hub/src/main/java/com/msa/hub/exception/ErrorCode.java
@@ -10,7 +10,8 @@ public enum ErrorCode {
     UNSUPPORTED_SORT_TYPE(HttpStatus.BAD_REQUEST, "지원하지 않는 정렬 방식입니다."),
     INVALID_ROLE(HttpStatus.UNAUTHORIZED, "허브 관리자 권한이 존재하지 않습니다."),
     DUPLICATE_HUB_NAME(HttpStatus.BAD_REQUEST, "이미 존재하는 허브입니다."),
-    HUB_NOT_FOUND(HttpStatus.NOT_FOUND, "일치하는 허브 정보를 찾을 수 없습니다.");
+    HUB_NOT_FOUND(HttpStatus.NOT_FOUND, "일치하는 허브 정보를 찾을 수 없습니다."),
+    HUB_ROUTE_NOT_FOUND(HttpStatus.NOT_FOUND, "일치하는 허브 경로 정보를 찾을 수 없습니다.");
     private final HttpStatus httpStatus;
     private final String message;
 }

--- a/msa.hub/src/main/java/com/msa/hub/presentation/controller/HubRouteController.java
+++ b/msa.hub/src/main/java/com/msa/hub/presentation/controller/HubRouteController.java
@@ -1,23 +1,35 @@
 package com.msa.hub.presentation.controller;
 
 
+import com.msa.hub.application.dto.HubRouteDetailResponse;
+import com.msa.hub.application.dto.HubRouteResponse;
 import com.msa.hub.application.service.HubRouteCreateService;
+import com.msa.hub.application.service.HubRouteReadService;
 import com.msa.hub.presentation.request.HubRouteCreateRequest;
 import com.msa.hub.presentation.response.ApiResponse;
+import com.msa.hub.presentation.response.PageResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort.Direction;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.data.web.SortDefault;
 import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("hub-routes")
+@RequestMapping("/hub-routes")
 public class HubRouteController {
 
     private final HubRouteCreateService hubRouteCreateService;
+    private final HubRouteReadService hubRouteReadService;
 
     @PostMapping
     @PreAuthorize("hasAuthority('MASTER')")
@@ -26,5 +38,20 @@ public class HubRouteController {
     ) {
         hubRouteCreateService.createRoute(request.sourceHubId(), request.destinationHubId());
         return ApiResponse.success();
+    }
+    @GetMapping
+    public ApiResponse<PageResponse<HubRouteResponse>> getHubRoutes(
+            @PageableDefault(size = 10)
+            @SortDefault.SortDefaults({
+                    @SortDefault(sort = "createdAt", direction = Direction.DESC),
+                    @SortDefault(sort = "updatedAt", direction = Direction.DESC)
+            })
+            Pageable pageable,
+            @RequestParam(required = false) String sourceHubId,
+            @RequestParam(required = false) String destinationHubId
+    ) {
+        return ApiResponse.success(PageResponse.of(
+                hubRouteReadService.findHubRoutes(pageable, sourceHubId, destinationHubId)
+        ));
     }
 }

--- a/msa.hub/src/main/java/com/msa/hub/presentation/controller/HubRouteController.java
+++ b/msa.hub/src/main/java/com/msa/hub/presentation/controller/HubRouteController.java
@@ -39,6 +39,14 @@ public class HubRouteController {
         hubRouteCreateService.createRoute(request.sourceHubId(), request.destinationHubId());
         return ApiResponse.success();
     }
+
+    @GetMapping("/{routeId}")
+    public ApiResponse<HubRouteDetailResponse> getHubRouteDetail(
+            @PathVariable String routeId
+    ) {
+        return ApiResponse.success(hubRouteReadService.getHubRouteDetail(routeId));
+    }
+
     @GetMapping
     public ApiResponse<PageResponse<HubRouteResponse>> getHubRoutes(
             @PageableDefault(size = 10)
@@ -53,5 +61,16 @@ public class HubRouteController {
         return ApiResponse.success(PageResponse.of(
                 hubRouteReadService.findHubRoutes(pageable, sourceHubId, destinationHubId)
         ));
+    }
+
+    /*
+    배송 서비스 클라이언트 용
+     */
+    @GetMapping("/delivery")
+    public HubRouteDetailResponse getHubRoute(
+            @RequestParam String sourceHubId,
+            @RequestParam String destinationHubId
+    ) {
+        return hubRouteReadService.findHubRouteBy(sourceHubId, destinationHubId);
     }
 }

--- a/msa.hub/src/main/java/com/msa/hub/presentation/response/PageResponse.java
+++ b/msa.hub/src/main/java/com/msa/hub/presentation/response/PageResponse.java
@@ -1,0 +1,18 @@
+package com.msa.hub.presentation.response;
+
+import java.util.List;
+import org.springframework.data.domain.Page;
+
+public record PageResponse<T> (
+        int totalPages,
+        int pageNumber,
+        List<T> content
+) {
+    public static <T> PageResponse<T> of(Page<T> page){
+        return new PageResponse<>(
+                page.getTotalPages(),
+                page.getNumber() + 1,
+                page.getContent()
+        );
+    }
+}


### PR DESCRIPTION
## Summary
<!-- 해당 PR에 어떤 작업이 포함됐는지 요약해주세요 -->
<!-- merge시 관련 이슈가 자동으로 close 되도록 이슈 번호를 작성해주세요 -->
- closed #42 -> main
- closed #44 -> main

허브 경로를 id 로 조회하는 API와 허브 경로를 생성 시간, 수정 시간의 정렬과 출발 허브, 도착 허브의 조건으로 검색하는 API를 개발했습니다. 배송지 쪽에서 호출하는 용도의 API도 포함됩니다.

## Key Changes
<!-- 주요 변경 사항을 기재해주세요 -->
- 쿼리 DSL 의존성 및 설정 추가
-  경유지 엔티티에 순서 필드 추가
- 응답 객체 생성
- read 용 허브 경로 서비스 생성

## Testing
<!-- 해당 작업이 성공된 것을 확인할 수 있는 방법을 기재해주세요 -->
<!-- 전/후 스크린샷을 첨부하기도 합니다 -->

- **검색**
![image](https://github.com/user-attachments/assets/01b2e62f-f9c4-4e61-a9f0-56ca339113e2)

목록 조회 시, 경유지 정보는 결과에 포함되지 않습니다.

- **단건 조회 성공**
![image](https://github.com/user-attachments/assets/51b1aeab-183a-4197-ab71-33e7cf74664c)


- **단건 조회 시, 일치하는 경로 정보가 없는 경우**
![image](https://github.com/user-attachments/assets/9f0f2827-4d68-4d2b-8607-3e2b61dfd412)

## To Reviewers
<!-- 리뷰어에게 전달하거나 논의하고 싶은 내용을 기재해주세요 -->
- 현재 경유지에 끝나는 허브의 정보까지 포함되도록 구현되어 있는 문제, 거리 계산 오류 문제가 있는데
해당 부분은 따로 브런치 생성해 수정하도록 하겠습니다!
- 정렬 조건은 추후 허브 명 등으로 추가될 수 있을 것 같습니다.
- 검색 조건에 삭제 여부 필터링은 적용하지 않았는데 해당 부분 추후 추가하도록 하겠습니다.
- 기타 궁금하신 점, 개선할 점 등 생각나시는 의견 있으시면 편하게 남겨주세요!