### PR TITLE
[Feat] 유저의 소속 허브를 등록하는 API

### DIFF
--- a/msa.hub/src/main/java/com/msa/hub/application/dto/UserDetailResponse.java
+++ b/msa.hub/src/main/java/com/msa/hub/application/dto/UserDetailResponse.java
@@ -8,6 +8,7 @@ public record UserDetailResponse(
         String email,
         String slackId,
         Role role,
+        String belongHubId,
         LocalDateTime createAt,
         LocalDateTime updatedAt
 ) {

--- a/msa.hub/src/main/java/com/msa/hub/domain/model/Hub.java
+++ b/msa.hub/src/main/java/com/msa/hub/domain/model/Hub.java
@@ -53,7 +53,7 @@ public class Hub extends BaseEntity {
     @Column(name="longitude", nullable=false)
     private Double longitude;
 
-    @Column(name="manager_id", nullable = false)
+    @Column(name="manager_id")
     private Long managerId;
 
     @OneToMany(mappedBy = "sourceHubId")
@@ -76,9 +76,15 @@ public class Hub extends BaseEntity {
         this.managerId = managerId;
     }
 
-    public static Hub createBy(String name, String city,
-                             String district, String streetName, String streetNumber, String addressDetail,
-                             Double latitude, Double longitude, Long managerId) {
+    public void setManager(Long managerId) {
+        this.managerId = managerId;
+    }
+
+    public static Hub createBy(
+            String name, String city,
+            String district, String streetName, String streetNumber, String addressDetail,
+            Double latitude, Double longitude
+    ) {
         return Hub.builder()
                 .name(name)
                 .city(city)
@@ -88,7 +94,6 @@ public class Hub extends BaseEntity {
                 .addressDetail(addressDetail)
                 .latitude(latitude)
                 .longitude(longitude)
-                .managerId(managerId)
                 .build();
     }
 

--- a/msa.hub/src/main/java/com/msa/hub/presentation/controller/HubController.java
+++ b/msa.hub/src/main/java/com/msa/hub/presentation/controller/HubController.java
@@ -29,8 +29,17 @@ public class HubController {
         return ApiResponse.success();
     }
 
+    @PostMapping("/manager")
+    public Boolean postManager(
+            @RequestParam(required = true) String hubId,
+            @RequestParam(required = true) Long userId
+    ) {
+        hubService.updateHubManager(hubId, userId);
+        return true;
+    }
+
     @GetMapping("/verify")
-    public Boolean verifyHub(@RequestParam(value = "hub_id") String hubId) {
+    public Boolean verifyHub(@RequestParam String hubId) {
         return true;
     }
 }

--- a/msa.user/src/main/java/com/msa/user/application/dto/UserDetailResponse.java
+++ b/msa.user/src/main/java/com/msa/user/application/dto/UserDetailResponse.java
@@ -11,6 +11,7 @@ public record UserDetailResponse(
         String slackId,
         Role role,
         String belongHubId,
+        String belongCompanyId,
         LocalDateTime createAt,
         LocalDateTime updatedAt
 ) {
@@ -22,6 +23,7 @@ public record UserDetailResponse(
                 user.getSlackId(),
                 user.getRole(),
                 user.getBelongHubId(),
+                user.getBelongCompanyId(),
                 user.getCreatedAt(),
                 user.getUpdatedAt()
         );

--- a/msa.user/src/main/java/com/msa/user/application/dto/UserDetailResponse.java
+++ b/msa.user/src/main/java/com/msa/user/application/dto/UserDetailResponse.java
@@ -10,6 +10,7 @@ public record UserDetailResponse(
         String email,
         String slackId,
         Role role,
+        String belongHubId,
         LocalDateTime createAt,
         LocalDateTime updatedAt
 ) {
@@ -20,6 +21,7 @@ public record UserDetailResponse(
                 user.getEmail(),
                 user.getSlackId(),
                 user.getRole(),
+                user.getBelongHubId(),
                 user.getCreatedAt(),
                 user.getUpdatedAt()
         );

--- a/msa.user/src/main/java/com/msa/user/application/service/HubService.java
+++ b/msa.user/src/main/java/com/msa/user/application/service/HubService.java
@@ -1,0 +1,8 @@
+package com.msa.user.application.service;
+
+import org.springframework.web.bind.annotation.RequestParam;
+
+public interface HubService {
+    Boolean verifyHub(@RequestParam String hubId);
+    Boolean postManager(@RequestParam String hubId, @RequestParam Long userId);
+}

--- a/msa.user/src/main/java/com/msa/user/common/exception/ErrorCode.java
+++ b/msa.user/src/main/java/com/msa/user/common/exception/ErrorCode.java
@@ -7,6 +7,8 @@ import org.springframework.http.HttpStatus;
 @Getter
 @AllArgsConstructor
 public enum ErrorCode {
+
+    INVALID_HUB(HttpStatus.BAD_REQUEST, "유효하지 않은 허브입니다."),
     INVALID_PASSWORD(HttpStatus.UNAUTHORIZED, "비밀번호가 일치하지 않습니다."),
     USER_NOT_FOUND(HttpStatus.NOT_FOUND, "일치하는 사용자 정보가 존재하지 않습니다."),
     DUPLICATE_USERNAME(HttpStatus.BAD_REQUEST, "이미 존재하는 사용자입니다.");

--- a/msa.user/src/main/java/com/msa/user/common/exception/ExceptionResponse.java
+++ b/msa.user/src/main/java/com/msa/user/common/exception/ExceptionResponse.java
@@ -1,6 +1,6 @@
 package com.msa.user.common.exception;
 
-public record ExceptionMessage(
+public record ExceptionResponse(
         String message
 ) {
 }

--- a/msa.user/src/main/java/com/msa/user/common/exception/GlobalControllerAdvice.java
+++ b/msa.user/src/main/java/com/msa/user/common/exception/GlobalControllerAdvice.java
@@ -1,10 +1,18 @@
 package com.msa.user.common.exception;
 
 
+import java.util.Arrays;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.authorization.AuthorizationDeniedException;
+import org.springframework.web.HttpRequestMethodNotSupportedException;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.MissingServletRequestParameterException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.servlet.resource.NoResourceFoundException;
 
 @Slf4j
 @RestControllerAdvice
@@ -13,8 +21,48 @@ public class GlobalControllerAdvice {
     private final String ERROR_LOG = "[ERROR] %s %s";
 
     @ExceptionHandler(UserException.class)
-    public ResponseEntity<ExceptionMessage> applicationException(final UserException e){
+    public ResponseEntity<ExceptionResponse> applicationException(final UserException e){
         log.error(String.format(ERROR_LOG, e.getHttpStatus(), e.getMessage()));
-        return ResponseEntity.status(e.getHttpStatus()).body(new ExceptionMessage(e.getMessage()));
+        return ResponseEntity.status(e.getHttpStatus()).body(new ExceptionResponse(e.getMessage()));
+    }
+
+    @ResponseStatus(HttpStatus.UNAUTHORIZED)
+    @ExceptionHandler(AuthorizationDeniedException.class)
+    public ExceptionResponse rr(final AuthorizationDeniedException e) {
+        log.error(String.format(ERROR_LOG, e.getMessage(), e.getClass().getName()));
+        return new ExceptionResponse("접근 권한이 존재하지 않습니다.");
+    }
+
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    @ExceptionHandler(NoResourceFoundException.class)
+    public ExceptionResponse handleNoResourceFoundException(NoResourceFoundException e) {
+        log.error(String.format(ERROR_LOG, e.getMessage(), e.getClass().getName()));
+        return new ExceptionResponse("지원하지 않는 경로입니다.");
+    }
+
+    @ResponseStatus(HttpStatus.METHOD_NOT_ALLOWED)
+    @ExceptionHandler(HttpRequestMethodNotSupportedException.class)
+    public ExceptionResponse httpReqMethodNotSupportException(final HttpRequestMethodNotSupportedException e){
+        log.error(String.format(ERROR_LOG, e.getMessage(), Arrays.toString(e.getSupportedMethods())));
+        return new ExceptionResponse("지원하지 않는 요청 방법입니다.");
+    }
+
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    @ExceptionHandler(MissingServletRequestParameterException.class)
+    public ExceptionResponse missingServletRequestParameter(final MissingServletRequestParameterException e) {
+        log.error(String.format(ERROR_LOG, e.getParameterName(), e.getMessage()));
+        return new ExceptionResponse("필요한 파라미터가 입력되지 않았습니다.");
+    }
+
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ExceptionResponse methodArgumentNotValidException(final MethodArgumentNotValidException e){
+        return new ExceptionResponse(e.getBindingResult().getAllErrors().get(0).getDefaultMessage());
+    }
+
+    @ExceptionHandler(RuntimeException.class)
+    public ExceptionResponse runtimeExceptionHandler(RuntimeException e) {
+        log.error(String.format(ERROR_LOG, e.getMessage(), e.getClass().getName()));
+        return new ExceptionResponse(e.getMessage());
     }
 }

--- a/msa.user/src/main/java/com/msa/user/domain/model/User.java
+++ b/msa.user/src/main/java/com/msa/user/domain/model/User.java
@@ -39,15 +39,18 @@ public class User extends BaseEntity {
     private Role role;
     @Column(name="belong_hub_id")
     private String belongHubId;
+    @Column(name = "belong_company_id")
+    private String belongCompanyId;
 
     @Builder(access = AccessLevel.PRIVATE)
-    private User(String username, String password, String email, String slackId, Role role, String belongHubId) {
+    private User(String username, String password, String email, String slackId, Role role, String belongHubId, String belongCompanyId) {
         this.username = username;
         this.password = password;
         this.email = email;
         this.slackId = slackId;
         this.role = role;
         this.belongHubId = belongHubId;
+        this.belongCompanyId = belongCompanyId;
     }
 
     public void setBelongHub(String belongHubId) {

--- a/msa.user/src/main/java/com/msa/user/domain/model/User.java
+++ b/msa.user/src/main/java/com/msa/user/domain/model/User.java
@@ -37,17 +37,26 @@ public class User extends BaseEntity {
     @Enumerated(EnumType.STRING)
     @Column(name="role")
     private Role role;
+    @Column(name="belong_hub_id")
+    private String belongHubId;
 
     @Builder(access = AccessLevel.PRIVATE)
-    private User(String username, String password, String email, String slackId, Role role) {
+    private User(String username, String password, String email, String slackId, Role role, String belongHubId) {
         this.username = username;
         this.password = password;
         this.email = email;
         this.slackId = slackId;
         this.role = role;
+        this.belongHubId = belongHubId;
     }
 
-    public static User createBy(String username, String password, String email, String slackId, Role role) {
+    public void setBelongHub(String belongHubId) {
+        this.belongHubId = belongHubId;
+    }
+
+    public static User createBy(
+            String username, String password, String email, String slackId, Role role
+    ) {
         return User.builder()
                 .username(username)
                 .password(password)

--- a/msa.user/src/main/java/com/msa/user/infrastructure/HubClient.java
+++ b/msa.user/src/main/java/com/msa/user/infrastructure/HubClient.java
@@ -1,0 +1,22 @@
+package com.msa.user.infrastructure;
+
+import com.msa.user.application.service.HubService;
+import com.msa.user.presentation.response.ApiResponse;
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+
+
+@FeignClient(name = "hub-service")
+public interface HubClient extends HubService {
+
+    @GetMapping("/hubs/verify")
+    Boolean verifyHub(@RequestParam String hubId);
+
+    @PostMapping("/hubs/manager")
+    Boolean postManager(
+            @RequestParam String hubId,
+            @RequestParam Long userId
+    );
+}

--- a/msa.user/src/main/java/com/msa/user/infrastructure/config/FeignConfig.java
+++ b/msa.user/src/main/java/com/msa/user/infrastructure/config/FeignConfig.java
@@ -1,0 +1,26 @@
+package com.msa.user.infrastructure.config;
+
+
+import feign.RequestInterceptor;
+import jakarta.servlet.http.HttpServletRequest;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.context.request.RequestContextHolder;
+import org.springframework.web.context.request.ServletRequestAttributes;
+
+@Configuration
+public class FeignConfig {
+    @Bean
+    public RequestInterceptor requestInterceptor() {
+        return requestTemplate -> {
+            ServletRequestAttributes attributes = (ServletRequestAttributes) RequestContextHolder.getRequestAttributes();
+            if (attributes != null) {
+                HttpServletRequest request = attributes.getRequest();
+                final String id = request.getHeader("X-User-Id");
+                final String role = request.getHeader("X-User-Role");
+                requestTemplate.header("X-User-Id", id);
+                requestTemplate.header("X-User-Role", role);
+            }
+        };
+    }
+}

--- a/msa.user/src/main/java/com/msa/user/presentation/controller/UserController.java
+++ b/msa.user/src/main/java/com/msa/user/presentation/controller/UserController.java
@@ -2,10 +2,15 @@ package com.msa.user.presentation.controller;
 
 import com.msa.user.application.dto.UserDetailResponse;
 import com.msa.user.application.service.UserService;
+import com.msa.user.presentation.request.SetBelongHubRequest;
 import com.msa.user.presentation.response.ApiResponse;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -21,6 +26,15 @@ public class UserController {
             @PathVariable Long userId
     ) {
         return ApiResponse.success(userService.getUser(userId));
+    }
+
+    @PostMapping("/belong-hub")
+    @PreAuthorize("hasAuthority('MASTER')")
+    public ApiResponse<Void> postUserBelongHub(
+            @Valid @RequestBody SetBelongHubRequest request
+    ) {
+        userService.setBelongHub(request.userId(), request.hubId());
+        return ApiResponse.success();
     }
 
 }

--- a/msa.user/src/main/java/com/msa/user/presentation/request/SetBelongHubRequest.java
+++ b/msa.user/src/main/java/com/msa/user/presentation/request/SetBelongHubRequest.java
@@ -1,0 +1,10 @@
+package com.msa.user.presentation.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
+public record SetBelongHubRequest(
+        @NotNull Long userId,
+        @NotBlank String hubId
+) {
+}


### PR DESCRIPTION
## Summary
<!-- 해당 PR에 어떤 작업이 포함됐는지 요약해주세요 -->
<!-- merge시 관련 이슈가 자동으로 close 되도록 이슈 번호를 작성해주세요 -->
- closed #46 -> main

관리자(MASTER)가 유저의 소속 허브를 등록하도록 하는 API 를 개발했습니다.

## Key Changes
<!-- 주요 변경 사항을 기재해주세요 -->

- 유저 단건 조회 결과에 소속 허브, 소속 업체 정보가 포함되도록 수정했습니다.
- 기존 허브 등록시에 매니저를 저장하지 않고 유저의 소속허브등록시 같이 등록되도록 변경했습니다.
- 유저쪽에 exception handler 추가했습니다.
## Testing
<!-- 해당 작업이 성공된 것을 확인할 수 있는 방법을 기재해주세요 -->
<!-- 전/후 스크린샷을 첨부하기도 합니다 -->
- **소속 허브 등록 성공**
![image](https://github.com/user-attachments/assets/f9ddf200-e1dc-474b-82c5-e44ed63a0c44)
DB 허브와 유저 양쪽에 등록되는 것을 확인했습니다.

- **유저 단건 조회 결과**
![image](https://github.com/user-attachments/assets/07d05067-eccc-4b9d-a9a4-32e5985ced8b)
소속 허브의 id가 함께 반환됩니다.

- **유저 단건 조회 : 소속 허브 없는 경우**
![image](https://github.com/user-attachments/assets/bf4add56-345c-40c0-acf0-ffd84dbc290a)
소속 허브가 없는 경우 null이 담겨 반환됩니다.

## To Reviewers
<!-- 리뷰어에게 전달하거나 논의하고 싶은 내용을 기재해주세요 -->
- 소속 허브 정보를 알 수 있도록 하기 위해 최대한 빠르게 구현하느라 허브에 기존 담당자가 있는 경우 등의 오류 처리를 포함하지 못했는데 해당 부분 추후 브런치 나눠 개발하도록 하겠습니다 😭
- 소속 업체도 엔티티에 추가, 응답에 포함되도록 수정했지만 등록 API는 업체 서비스 보고 따로 해야될 것 같습니다! 
- 기타 궁금하신 점, 개선할 점 등 생각나시는 의견 있으시면 편하게 남겨주세요!