### PR TITLE
[Feat] 허브 단건 조회 API

### DIFF
--- a/msa.hub/src/main/java/com/msa/hub/application/dto/HubDetailResponse.java
+++ b/msa.hub/src/main/java/com/msa/hub/application/dto/HubDetailResponse.java
@@ -1,0 +1,36 @@
+package com.msa.hub.application.dto;
+
+import com.msa.hub.domain.model.Hub;
+import java.time.LocalDateTime;
+
+public record HubDetailResponse(
+        String id,
+        String name,
+        String city,
+        String district,
+        String streetName,
+        String streetNumber,
+        String addressDetail,
+        Double latitude,
+        Double longitude,
+        Long managerId,
+        LocalDateTime createdAt,
+        LocalDateTime updatedAt
+) {
+    public static HubDetailResponse convertToResponse(Hub hub) {
+        return new HubDetailResponse(
+                hub.getId(),
+                hub.getName(),
+                hub.getCity(),
+                hub.getDistrict(),
+                hub.getStreetName(),
+                hub.getStreetNumber(),
+                hub.getAddressDetail(),
+                hub.getLatitude(),
+                hub.getLongitude(),
+                hub.getManagerId(),
+                hub.getCreatedAt(),
+                hub.getUpdatedAt()
+        );
+    }
+}

--- a/msa.hub/src/main/java/com/msa/hub/application/dto/HubDetailResponse.java
+++ b/msa.hub/src/main/java/com/msa/hub/application/dto/HubDetailResponse.java
@@ -17,7 +17,7 @@ public record HubDetailResponse(
         LocalDateTime createdAt,
         LocalDateTime updatedAt
 ) {
-    public static HubDetailResponse convertToResponse(Hub hub) {
+    public static HubDetailResponse from(Hub hub) {
         return new HubDetailResponse(
                 hub.getId(),
                 hub.getName(),

--- a/msa.hub/src/main/java/com/msa/hub/application/service/HubService.java
+++ b/msa.hub/src/main/java/com/msa/hub/application/service/HubService.java
@@ -1,6 +1,7 @@
 package com.msa.hub.application.service;
 
 
+import com.msa.hub.application.dto.HubDetailResponse;
 import com.msa.hub.application.dto.Role;
 import com.msa.hub.domain.model.Hub;
 import com.msa.hub.domain.repository.HubRepository;
@@ -34,6 +35,13 @@ public class HubService {
                         request.latitude(),
                         request.longitude()
                 )
+        );
+    }
+
+    public HubDetailResponse getHubDetail(final String id) {
+        return HubDetailResponse.convertToResponse(
+                hubRepository.findByIdAndIsDeleted(id, false)
+                        .orElseThrow(()->new HubException(ErrorCode.HUB_NOT_FOUND))
         );
     }
 

--- a/msa.hub/src/main/java/com/msa/hub/application/service/HubService.java
+++ b/msa.hub/src/main/java/com/msa/hub/application/service/HubService.java
@@ -39,7 +39,7 @@ public class HubService {
     }
 
     public HubDetailResponse getHubDetail(final String id) {
-        return HubDetailResponse.convertToResponse(
+        return HubDetailResponse.from(
                 hubRepository.findByIdAndIsDeleted(id, false)
                         .orElseThrow(()->new HubException(ErrorCode.HUB_NOT_FOUND))
         );

--- a/msa.hub/src/main/java/com/msa/hub/domain/model/BaseEntity.java
+++ b/msa.hub/src/main/java/com/msa/hub/domain/model/BaseEntity.java
@@ -16,9 +16,9 @@ import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 @Getter
 @MappedSuperclass
 public abstract class BaseEntity {
-    @Column(name="is_deleted")
+    @Column(name="is_deleted", nullable = false)
     @ColumnDefault("false")
-    private Boolean isDeleted;
+    private Boolean isDeleted = false;
 
     @CreatedDate
     @Column(name="created_at", updatable = false)

--- a/msa.hub/src/main/java/com/msa/hub/domain/repository/HubRepository.java
+++ b/msa.hub/src/main/java/com/msa/hub/domain/repository/HubRepository.java
@@ -1,10 +1,12 @@
 package com.msa.hub.domain.repository;
 
 import com.msa.hub.domain.model.Hub;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface HubRepository extends JpaRepository<Hub, String> {
+    Optional<Hub> findByIdAndIsDeleted(String id, boolean isDeleted);
     boolean existsByName(String name);
 }

--- a/msa.hub/src/main/java/com/msa/hub/presentation/controller/HubController.java
+++ b/msa.hub/src/main/java/com/msa/hub/presentation/controller/HubController.java
@@ -1,5 +1,6 @@
 package com.msa.hub.presentation.controller;
 
+import com.msa.hub.application.dto.HubDetailResponse;
 import com.msa.hub.application.service.HubService;
 import com.msa.hub.presentation.request.HubCreateRequest;
 import com.msa.hub.presentation.response.ApiResponse;
@@ -7,6 +8,7 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -29,6 +31,13 @@ public class HubController {
         return ApiResponse.success();
     }
 
+    @GetMapping("/{hubId}")
+    public ApiResponse<HubDetailResponse> findHub(
+            @PathVariable String hubId
+    ) {
+        return ApiResponse.success(hubService.getHubDetail(hubId));
+    }
+
     @PostMapping("/manager")
     public Boolean postManager(
             @RequestParam(required = true) String hubId,
@@ -40,6 +49,7 @@ public class HubController {
 
     @GetMapping("/verify")
     public Boolean verifyHub(@RequestParam String hubId) {
+        hubService.getHubDetail(hubId);
         return true;
     }
 }


### PR DESCRIPTION
## Summary
<!-- 해당 PR에 어떤 작업이 포함됐는지 요약해주세요 -->
<!-- merge시 관련 이슈가 자동으로 close 되도록 이슈 번호를 작성해주세요 -->
- closed #55 -> main

허브 id와 일치하는 허브 정보를 조회하는 API를 개발했습니다.
## Key Changes
<!-- 주요 변경 사항을 기재해주세요 -->
- 응답 객체 생성
- BaseEntity에서 isDeleted 필드에 nullable = false 속성 추가
  - 설정하지 않으면 생성시 null 이 들어가 조회 조건(isDeleted=false)을 충족시키지 못해 수정했습니다 

## Testing
<!-- 해당 작업이 성공된 것을 확인할 수 있는 방법을 기재해주세요 -->
<!-- 전/후 스크린샷을 첨부하기도 합니다 -->

**조회 성공 결과**

![image](https://github.com/user-attachments/assets/5f1cf806-3401-454c-abdb-4eedfbdb66b7)


## To Reviewers
<!-- 리뷰어에게 전달하거나 논의하고 싶은 내용을 기재해주세요 -->
- 궁금하신 점, 개선할 점 등 생각나시는 의견 있으시면 편하게 남겨주세요!