### PR TITLE
[Feat] 유저 자신의 정보 수정 API

### DIFF
--- a/msa.user/src/main/java/com/msa/user/application/service/UserService.java
+++ b/msa.user/src/main/java/com/msa/user/application/service/UserService.java
@@ -5,9 +5,12 @@ import com.msa.user.domain.model.User;
 import com.msa.user.domain.repository.UserRepository;
 import com.msa.user.common.exception.ErrorCode;
 import com.msa.user.common.exception.UserException;
+import com.msa.user.presentation.request.UserUpdateRequest;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
 
 @Service
 @RequiredArgsConstructor
@@ -15,11 +18,27 @@ import org.springframework.transaction.annotation.Transactional;
 public class UserService {
 
     private final HubService hubService;
+    private final PasswordEncoder passwordEncoder;
     private final UserRepository userRepository;
 
     public UserDetailResponse getUser(final Long userId) {
         User user = getUserOrException(userId);
         return UserDetailResponse.from(user);
+    }
+
+    @Transactional
+    public void updateUser(final Long userId, final UserUpdateRequest request) {
+        User user = getUserOrException(userId);
+        if(request.username() != null) {
+            nameValidation(request.username());
+        }
+        user.update(
+                request.username(),
+                (request.password()==null) ? null
+                        : passwordEncoder.encode(request.password()),
+                request.email(),
+                request.slackId()
+        );
     }
 
     @Transactional

--- a/msa.user/src/main/java/com/msa/user/application/service/UserService.java
+++ b/msa.user/src/main/java/com/msa/user/application/service/UserService.java
@@ -32,10 +32,13 @@ public class UserService {
         hubService.postManager(hubId, userId);
     }
 
-
-
     private User getUserOrException(final Long userId) {
         return userRepository.findById(userId)
                 .orElseThrow(()-> new UserException(ErrorCode.USER_NOT_FOUND));
+    }
+
+    private void nameValidation(String username) {
+        if(userRepository.existsByUsername(username))
+            throw new UserException(ErrorCode.DUPLICATE_USERNAME);
     }
 }

--- a/msa.user/src/main/java/com/msa/user/domain/model/User.java
+++ b/msa.user/src/main/java/com/msa/user/domain/model/User.java
@@ -53,6 +53,13 @@ public class User extends BaseEntity {
         this.belongCompanyId = belongCompanyId;
     }
 
+    public void update(String username, String password, String email, String slackId) {
+        if (username!=null) this.username = username;
+        if (password!=null) this.password = password;
+        if (email!=null) this.email = email;
+        if (slackId!=null) this.slackId = slackId;
+    }
+
     public void setBelongHub(String belongHubId) {
         this.belongHubId = belongHubId;
     }

--- a/msa.user/src/main/java/com/msa/user/presentation/controller/UserController.java
+++ b/msa.user/src/main/java/com/msa/user/presentation/controller/UserController.java
@@ -3,16 +3,21 @@ package com.msa.user.presentation.controller;
 import com.msa.user.application.dto.UserDetailResponse;
 import com.msa.user.application.service.UserService;
 import com.msa.user.presentation.request.SetBelongHubRequest;
+import com.msa.user.presentation.request.UserUpdateRequest;
 import com.msa.user.presentation.response.ApiResponse;
 import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotNull;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+
 
 @RestController
 @RequiredArgsConstructor
@@ -26,6 +31,15 @@ public class UserController {
             @PathVariable Long userId
     ) {
         return ApiResponse.success(userService.getUser(userId));
+    }
+
+    @PatchMapping()
+    public ApiResponse<Void> updateUser(
+            Authentication authentication,
+            @NotNull @RequestBody UserUpdateRequest request
+    ) {
+        userService.updateUser(Long.valueOf(authentication.getName()), request);
+        return ApiResponse.success();
     }
 
     @PostMapping("/belong-hub")

--- a/msa.user/src/main/java/com/msa/user/presentation/controller/UserController.java
+++ b/msa.user/src/main/java/com/msa/user/presentation/controller/UserController.java
@@ -33,7 +33,7 @@ public class UserController {
         return ApiResponse.success(userService.getUser(userId));
     }
 
-    @PatchMapping()
+    @PatchMapping
     public ApiResponse<Void> updateUser(
             Authentication authentication,
             @NotNull @RequestBody UserUpdateRequest request

--- a/msa.user/src/main/java/com/msa/user/presentation/request/UserUpdateRequest.java
+++ b/msa.user/src/main/java/com/msa/user/presentation/request/UserUpdateRequest.java
@@ -1,0 +1,9 @@
+package com.msa.user.presentation.request;
+
+public record UserUpdateRequest(
+        String username,
+        String password,
+        String email,
+        String slackId
+) {
+}


### PR DESCRIPTION
## Summary
<!-- 해당 PR에 어떤 작업이 포함됐는지 요약해주세요 -->
<!-- merge시 관련 이슈가 자동으로 close 되도록 이슈 번호를 작성해주세요 -->
- closed #56 -> main

로그인한 유저 본인의 기본 정보를 수정할 수 있는 API 를 개발했습니다.
수정할 정보만 요청에 포함해 보내면 되고 username 의 경우 이미 존재하면 오류를 반환합니다.
## Key Changes
<!-- 주요 변경 사항을 기재해주세요 -->
- 유저 엔티티에 업데이트 메서드 추가
- 업데이트 요청 객체 추가

## Testing
<!-- 해당 작업이 성공된 것을 확인할 수 있는 방법을 기재해주세요 -->
<!-- 전/후 스크린샷을 첨부하기도 합니다 -->

- **실패** 이미 있는 이름을 요청할 경우

![image](https://github.com/user-attachments/assets/c033740d-9d1e-4e0f-a516-bc12244c83db)

- **성공**

![image](https://github.com/user-attachments/assets/ee170395-0e65-41bb-a9ce-e1aad73bfb2c)

데이터베이스에 요청 정보, 업데이트 로그 반영 확인했습니다.

## To Reviewers
<!-- 리뷰어에게 전달하거나 논의하고 싶은 내용을 기재해주세요 -->
- 로그인한 유저 본인의 기본적인 정보만 변경할 수 있습니다.
- 기타 궁금하신 점, 개선할 점 등 생각나시는 의견 있으시면 편하게 남겨주세요!