### PR TITLE
[Feat] 유저 목록 조회 및 검색 API

### DIFF
--- a/msa.user/build.gradle
+++ b/msa.user/build.gradle
@@ -53,6 +53,14 @@ dependencies {
 
 	// jpa
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+
+	// querydsl
+	implementation "com.querydsl:querydsl-jpa:5.0.0:jakarta"
+	annotationProcessor "com.querydsl:querydsl-apt:5.0.0:jakarta"
+	annotationProcessor "jakarta.annotation:jakarta.annotation-api"
+	annotationProcessor "jakarta.persistence:jakarta.persistence-api"
+	implementation 'org.jetbrains:annotations:24.1.0'
+
 }
 
 dependencyManagement {

--- a/msa.user/src/main/java/com/msa/user/application/dto/UserBasicResponse.java
+++ b/msa.user/src/main/java/com/msa/user/application/dto/UserBasicResponse.java
@@ -1,0 +1,22 @@
+package com.msa.user.application.dto;
+
+import com.msa.user.domain.model.Role;
+import com.msa.user.domain.model.User;
+
+public record UserBasicResponse(
+        Long userId,
+        String username,
+        Role role,
+        String belongHubId,
+        String belongCompanyId
+) {
+    public static UserBasicResponse toUserPageResponse(User user) {
+        return new UserBasicResponse(
+                user.getId(),
+                user.getUsername(),
+                user.getRole(),
+                user.getBelongHubId(),
+                user.getBelongCompanyId()
+        );
+    }
+}

--- a/msa.user/src/main/java/com/msa/user/application/service/UserService.java
+++ b/msa.user/src/main/java/com/msa/user/application/service/UserService.java
@@ -1,12 +1,16 @@
 package com.msa.user.application.service;
 
 import com.msa.user.application.dto.UserDetailResponse;
+import com.msa.user.application.dto.UserBasicResponse;
+import com.msa.user.domain.model.Role;
 import com.msa.user.domain.model.User;
 import com.msa.user.domain.repository.UserRepository;
 import com.msa.user.common.exception.ErrorCode;
 import com.msa.user.common.exception.UserException;
 import com.msa.user.presentation.request.UserUpdateRequest;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -24,6 +28,14 @@ public class UserService {
     public UserDetailResponse getUser(final Long userId) {
         User user = getUserOrException(userId);
         return UserDetailResponse.from(user);
+    }
+
+    public Page<UserBasicResponse> findUsers(
+            Pageable pageable, String username, Role role, String belongHudId, String belongCompanyId
+    ) {
+        return userRepository
+                .findUsersWith(pageable, username, role, belongHudId, belongCompanyId)
+                .map(UserBasicResponse::toUserPageResponse);
     }
 
     @Transactional

--- a/msa.user/src/main/java/com/msa/user/common/exception/ErrorCode.java
+++ b/msa.user/src/main/java/com/msa/user/common/exception/ErrorCode.java
@@ -7,7 +7,7 @@ import org.springframework.http.HttpStatus;
 @Getter
 @AllArgsConstructor
 public enum ErrorCode {
-
+    UNSUPPORTED_SORT_TYPE(HttpStatus.BAD_REQUEST, "지원하지 않는 정렬 방식입니다."),
     INVALID_HUB(HttpStatus.BAD_REQUEST, "유효하지 않은 허브입니다."),
     INVALID_PASSWORD(HttpStatus.UNAUTHORIZED, "비밀번호가 일치하지 않습니다."),
     USER_NOT_FOUND(HttpStatus.NOT_FOUND, "일치하는 사용자 정보가 존재하지 않습니다."),

--- a/msa.user/src/main/java/com/msa/user/domain/config/QueryDslConfig.java
+++ b/msa.user/src/main/java/com/msa/user/domain/config/QueryDslConfig.java
@@ -1,0 +1,19 @@
+package com.msa.user.domain.config;
+
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@RequiredArgsConstructor
+public class QueryDslConfig {
+    private final EntityManager entityManager;
+
+    @Bean
+    public JPAQueryFactory jPAQueryFactory() {
+        return new JPAQueryFactory(entityManager);
+    }
+}

--- a/msa.user/src/main/java/com/msa/user/domain/model/BaseEntity.java
+++ b/msa.user/src/main/java/com/msa/user/domain/model/BaseEntity.java
@@ -17,9 +17,9 @@ import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 @Getter
 @MappedSuperclass
 public abstract class BaseEntity {
-    @Column(name="is_deleted") // 삭제 여부
+    @Column(name="is_deleted", nullable = false)
     @ColumnDefault("false")
-    private Boolean isDeleted;
+    private Boolean isDeleted = false;
 
     @CreatedDate
     @Column(name="created_at", updatable = false)

--- a/msa.user/src/main/java/com/msa/user/domain/repository/UserCustomRepository.java
+++ b/msa.user/src/main/java/com/msa/user/domain/repository/UserCustomRepository.java
@@ -1,0 +1,12 @@
+package com.msa.user.domain.repository;
+
+
+import com.msa.user.domain.model.Role;
+import com.msa.user.domain.model.User;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+public interface UserCustomRepository {
+    Page<User> findUsersWith(
+            Pageable pageable, String username, Role role, String belongHudId, String belongCompanyId);
+}

--- a/msa.user/src/main/java/com/msa/user/domain/repository/UserCustomRepositoryImpl.java
+++ b/msa.user/src/main/java/com/msa/user/domain/repository/UserCustomRepositoryImpl.java
@@ -1,0 +1,99 @@
+package com.msa.user.domain.repository;
+
+import static com.msa.user.domain.model.QUser.user;
+
+import com.msa.user.common.exception.ErrorCode;
+import com.msa.user.common.exception.UserException;
+import com.msa.user.domain.model.Role;
+import com.msa.user.domain.model.User;
+import com.querydsl.core.BooleanBuilder;
+import com.querydsl.core.types.OrderSpecifier;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.core.types.dsl.ComparableExpressionBase;
+import com.querydsl.jpa.impl.JPAQuery;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.support.PageableExecutionUtils;
+import org.springframework.stereotype.Repository;
+
+
+@Repository
+@RequiredArgsConstructor
+public class UserCustomRepositoryImpl implements UserCustomRepository {
+
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public Page<User> findUsersWith(
+            Pageable pageable, String username, Role role, String belongHudId, String belongCompanyId
+    ) {
+        BooleanBuilder booleanBuilder = getBooleanBuilder(username, role, belongHudId, belongCompanyId);
+        List<User> results = queryFactory.selectFrom(user)
+                .where(booleanBuilder)
+                .orderBy(getOrderSpecifiers(pageable))
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize())
+                .fetch();
+        JPAQuery<Long> count = queryFactory.select(user.count())
+                .from(user)
+                .where(booleanBuilder);
+        return PageableExecutionUtils.getPage(results, pageable, count::fetchOne);
+    }
+
+    private BooleanBuilder getBooleanBuilder(
+            String username, Role role, String belongHudId, String belongCompanyId
+    ) {
+        BooleanBuilder builder = new BooleanBuilder();
+        builder.and(likeUsername(username));
+        builder.and(eqRole(role));
+        builder.and(eqBelongHubId(belongHudId));
+        builder.and(eqBelongCompanyId(belongCompanyId));
+        builder.and(user.isDeleted.eq(false));
+        return builder;
+    }
+
+    private BooleanExpression likeUsername(String username) {
+        return user.username.like("%" + ((username!=null) ? username  : "") + "%");
+    }
+
+    private BooleanExpression eqRole(Role role) {
+        return role != null ? user.role.eq(role) : null;
+    }
+
+    private BooleanExpression eqBelongHubId(String belongHudId) {
+        return belongHudId != null ? user.belongHubId.eq(belongHudId) : null;
+    }
+
+    private BooleanExpression eqBelongCompanyId(String belongCompanyId) {
+        return belongCompanyId != null ? user.belongCompanyId.eq(belongCompanyId) : null;
+    }
+
+    private OrderSpecifier<?>[] getOrderSpecifiers(Pageable pageable) {
+        return pageable.getSort().stream()
+                .map(order -> {
+                    ComparableExpressionBase<?> sortPath = getSortPath(order.getProperty());
+                    return new OrderSpecifier<>(
+                            order.isAscending()
+                                    ? com.querydsl.core.types.Order.ASC
+                                    : com.querydsl.core.types.Order.DESC,
+                            sortPath);
+                })
+                .toArray(OrderSpecifier[]::new);
+    }
+
+    /*
+    User 정렬 기준
+     */
+    private ComparableExpressionBase<?> getSortPath(String property) {
+        return switch (property) {
+            case "username" -> user.username;
+            case "createdAt" -> user.createdAt;
+            case "updatedAt" -> user.updatedAt;
+            default -> throw new UserException(ErrorCode.UNSUPPORTED_SORT_TYPE);
+        };
+    }
+
+}

--- a/msa.user/src/main/java/com/msa/user/domain/repository/UserRepository.java
+++ b/msa.user/src/main/java/com/msa/user/domain/repository/UserRepository.java
@@ -6,7 +6,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
-public interface UserRepository extends JpaRepository<User, Long> {
+public interface UserRepository extends JpaRepository<User, Long>, UserCustomRepository {
     boolean existsByUsername(String username);
     Optional<User> findByUsername(String username);
 }

--- a/msa.user/src/main/java/com/msa/user/presentation/controller/UserController.java
+++ b/msa.user/src/main/java/com/msa/user/presentation/controller/UserController.java
@@ -1,13 +1,20 @@
 package com.msa.user.presentation.controller;
 
 import com.msa.user.application.dto.UserDetailResponse;
+import com.msa.user.application.dto.UserBasicResponse;
 import com.msa.user.application.service.UserService;
+import com.msa.user.domain.model.Role;
 import com.msa.user.presentation.request.SetBelongHubRequest;
 import com.msa.user.presentation.request.UserUpdateRequest;
 import com.msa.user.presentation.response.ApiResponse;
+import com.msa.user.presentation.response.PageResponse;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotNull;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort.Direction;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.data.web.SortDefault;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -16,6 +23,7 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 
@@ -31,6 +39,26 @@ public class UserController {
             @PathVariable Long userId
     ) {
         return ApiResponse.success(userService.getUser(userId));
+    }
+
+    @GetMapping
+    @PreAuthorize("hasAuthority('MASTER')")
+    public ApiResponse<PageResponse<UserBasicResponse>> getUser(
+            @PageableDefault(size = 10)
+            @SortDefault.SortDefaults({
+                    @SortDefault(sort = "username", direction = Direction.ASC),
+                    @SortDefault(sort = "createdAt", direction = Direction.DESC),
+                    @SortDefault(sort = "updatedAt", direction = Direction.DESC)
+            })
+            Pageable pageable,
+            @RequestParam(required = false) String username,
+            @RequestParam(required = false) Role role,
+            @RequestParam(required = false) String belongHudId,
+            @RequestParam(required = false) String belongCompanyId
+    ) {
+        return ApiResponse.success(PageResponse.of(
+                userService.findUsers(pageable, username, role, belongHudId, belongCompanyId))
+        );
     }
 
     @PatchMapping

--- a/msa.user/src/main/java/com/msa/user/presentation/response/PageResponse.java
+++ b/msa.user/src/main/java/com/msa/user/presentation/response/PageResponse.java
@@ -1,0 +1,18 @@
+package com.msa.user.presentation.response;
+
+import java.util.List;
+import org.springframework.data.domain.Page;
+
+public record PageResponse<T> (
+        int totalPages,
+        int pageNumber,
+        List<T> content
+) {
+    public static <T> PageResponse<T> of(Page<T> page){
+        return new PageResponse<>(
+                page.getTotalPages(),
+                page.getNumber() + 1,
+                page.getContent()
+        );
+    }
+}


### PR DESCRIPTION
## Summary
<!-- 해당 PR에 어떤 작업이 포함됐는지 요약해주세요 -->
<!-- merge시 관련 이슈가 자동으로 close 되도록 이슈 번호를 작성해주세요 -->
- closed #67 -> main

유저 목록 조회 및 검색 API를 개발했습니다.
MASTER 권한의 유저만 접근 가능합니다.
## Key Changes
<!-- 주요 변경 사항을 기재해주세요 -->
- 쿼리 DSL 설정 추가
- 페이지용 응답 객체 추가


## Testing
<!-- 해당 작업이 성공된 것을 확인할 수 있는 방법을 기재해주세요 -->
<!-- 전/후 스크린샷을 첨부하기도 합니다 -->

- **정렬 기준 넣어서 조회**
![image](https://github.com/user-attachments/assets/3f795102-06da-4157-932f-92d391ee0f79)


- **일치하는 ROLE 검색**
![image](https://github.com/user-attachments/assets/a7c56195-73f7-48cf-812e-6afffb505a57)


- **파라미터와 부분 일치하는 이름 검색**
![image](https://github.com/user-attachments/assets/04a840ee-8086-48d1-babe-4a150407e13e)


## To Reviewers
<!-- 리뷰어에게 전달하거나 논의하고 싶은 내용을 기재해주세요 -->
- createdAt 등의 로그 정보는 단건 조회를 통해 확인하도록 목록조회에는 제외했습니다
- 궁금하신 점, 개선할 점 등 생각나시는 의견 있으시면 편하게 남겨주세요!