### PR TITLE
[Feat] 현재 로그인한 유저 삭제 API

### DIFF
--- a/msa.user/src/main/java/com/msa/user/application/service/UserService.java
+++ b/msa.user/src/main/java/com/msa/user/application/service/UserService.java
@@ -63,6 +63,12 @@ public class UserService {
         hubService.postManager(hubId, userId);
     }
 
+    @Transactional
+    public void deleteUser(final Long userId) {
+        User user = getUserOrException(userId);
+        user.deleteBase(userId);
+    }
+
     private User getUserOrException(final Long userId) {
         return userRepository.findById(userId)
                 .orElseThrow(()-> new UserException(ErrorCode.USER_NOT_FOUND));

--- a/msa.user/src/main/java/com/msa/user/domain/model/BaseEntity.java
+++ b/msa.user/src/main/java/com/msa/user/domain/model/BaseEntity.java
@@ -43,4 +43,10 @@ public abstract class BaseEntity {
     @Column(name="deleted_by")
     private String deletedBy;
 
+    public void deleteBase(Long userId) {
+        this.isDeleted = true;
+        this.deletedAt = LocalDateTime.now();
+        this.deletedBy = String.valueOf(userId);
+    }
+
 }

--- a/msa.user/src/main/java/com/msa/user/presentation/controller/UserController.java
+++ b/msa.user/src/main/java/com/msa/user/presentation/controller/UserController.java
@@ -11,12 +11,15 @@ import com.msa.user.presentation.response.PageResponse;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotNull;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort.Direction;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.data.web.SortDefault;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.Authentication;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -76,6 +79,14 @@ public class UserController {
             @Valid @RequestBody SetBelongHubRequest request
     ) {
         userService.setBelongHub(request.userId(), request.hubId());
+        return ApiResponse.success();
+    }
+
+    @DeleteMapping
+    public ApiResponse<Void> deleteUser(
+            Authentication authentication
+    ) {
+        userService.deleteUser(Long.valueOf(authentication.getName()));
         return ApiResponse.success();
     }
 


### PR DESCRIPTION
## Summary
<!-- 해당 PR에 어떤 작업이 포함됐는지 요약해주세요 -->
<!-- merge시 관련 이슈가 자동으로 close 되도록 이슈 번호를 작성해주세요 -->
- closed #82 -> main

현재 로그인한 유저를 삭제하는 API를 개발했습니다.
## Key Changes
<!-- 주요 변경 사항을 기재해주세요 -->
- BaseEntity에 삭제 메서드 추가


## Testing
<!-- 해당 작업이 성공된 것을 확인할 수 있는 방법을 기재해주세요 -->
<!-- 전/후 스크린샷을 첨부하기도 합니다 -->

- 요청
![image](https://github.com/user-attachments/assets/030f1dbe-61a0-44ff-9d99-70ea9f0111b4)

실제 데이터베이스에 반영된 것을 확인했습니다.

## To Reviewers
<!-- 리뷰어에게 전달하거나 논의하고 싶은 내용을 기재해주세요 -->
- 궁금하신 점, 개선할 점 등 생각나시는 의견 있으시면 편하게 남겨주세요!