### PR TITLE
[Feat] 허브 삭제, 허브 경로 삭제 API

### DIFF
--- a/msa.hub/src/main/java/com/msa/hub/application/service/HubRouteUpdateService.java
+++ b/msa.hub/src/main/java/com/msa/hub/application/service/HubRouteUpdateService.java
@@ -1,12 +1,13 @@
 package com.msa.hub.application.service;
 
+import com.msa.hub.common.exception.ErrorCode;
+import com.msa.hub.common.exception.HubException;
 import com.msa.hub.domain.model.HubRoute;
 import com.msa.hub.domain.model.Waypoint;
 import com.msa.hub.domain.repository.HubRouteRepository;
 import com.msa.hub.domain.repository.WaypointRepository;
-import com.msa.hub.exception.ErrorCode;
-import com.msa.hub.exception.HubException;
 import lombok.RequiredArgsConstructor;
+import org.springframework.cache.annotation.CacheEvict;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -17,12 +18,14 @@ public class HubRouteUpdateService {
     private final HubRouteRepository hubRouteRepository;
     private final WaypointRepository waypointRepository;
 
+    @CacheEvict(cacheNames = "hub_routes_cache", allEntries = true)
     public void updateHubRouteDetail(String routeId, Double totalDistance, Long totalDuration) {
         HubRoute hubRoute = hubRouteRepository.findById(routeId)
                 .orElseThrow(()-> new HubException(ErrorCode.HUB_ROUTE_NOT_FOUND));
         hubRoute.updateTotalDetail(totalDistance, totalDuration);
     }
 
+    @CacheEvict(cacheNames = "hub_routes_cache", allEntries = true)
     public void updateWaypointDetail(
             String waypointId, Double distanceFromPrevious, Integer durationFromPrevious
     ) {
@@ -34,4 +37,12 @@ public class HubRouteUpdateService {
                .orElseThrow(()-> new HubException(ErrorCode.HUB_ROUTE_NOT_FOUND));
          */
     }
+
+    @CacheEvict(cacheNames = "hub_routes_cache", allEntries = true)
+    public void deleteHubRoute(String routeId, Long userId) {
+        HubRoute hubRoute = hubRouteRepository.findById(routeId)
+                .orElseThrow(()-> new HubException(ErrorCode.HUB_ROUTE_NOT_FOUND));
+        hubRoute.softDeleteHubRoute(userId);
+    }
+
 }

--- a/msa.hub/src/main/java/com/msa/hub/application/service/HubService.java
+++ b/msa.hub/src/main/java/com/msa/hub/application/service/HubService.java
@@ -4,6 +4,7 @@ package com.msa.hub.application.service;
 import com.msa.hub.application.dto.HubBasicResponse;
 import com.msa.hub.application.dto.HubDetailResponse;
 import com.msa.hub.domain.model.Hub;
+import com.msa.hub.domain.model.HubRoute;
 import com.msa.hub.domain.repository.HubRepository;
 import com.msa.hub.common.exception.ErrorCode;
 import com.msa.hub.common.exception.HubException;
@@ -12,6 +13,7 @@ import com.msa.hub.presentation.request.HubUpdateRequest;
 import lombok.RequiredArgsConstructor;
 import org.springframework.cache.annotation.CacheEvict;
 import org.springframework.cache.annotation.Cacheable;
+import org.springframework.cache.annotation.Caching;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
@@ -23,6 +25,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class HubService {
 
     private final HubRepository hubRepository;
+    private final UserService userService;
 
     @Transactional
     @CacheEvict(cacheNames = "hub_list_cache", allEntries = true)
@@ -75,6 +78,19 @@ public class HubService {
     public void updateHubManager(final String hubId, final Long userId) {
         Hub hub = getHubOrException(hubId);
         hub.setManager(userId);
+    }
+
+    @Transactional
+    @Caching(evict = {
+            @CacheEvict(cacheNames = "hub_list_cache", allEntries = true),
+            @CacheEvict(cacheNames = "hub_routes_cache", allEntries = true)
+    })
+    public void deleteHub(final String hubId, final Long userId) {
+        Hub hub = getHubOrException(hubId);
+        if(hub.getManagerId() != null) {
+            userService.detachBelongHub(hub.getManagerId());
+        }
+        hub.softDeleteHub(userId);
     }
 
     private Hub getHubOrException(final String hubId) {

--- a/msa.hub/src/main/java/com/msa/hub/application/service/UserService.java
+++ b/msa.hub/src/main/java/com/msa/hub/application/service/UserService.java
@@ -1,9 +1,8 @@
 package com.msa.hub.application.service;
 
-import com.msa.hub.application.dto.UserDetailResponse;
-import com.msa.hub.presentation.response.ApiResponse;
-import org.springframework.web.bind.annotation.PathVariable;
+
+import org.springframework.web.bind.annotation.RequestParam;
 
 public interface UserService {
-    ApiResponse<UserDetailResponse> findUser(@PathVariable Long userId);
+    Boolean detachBelongHub(@RequestParam Long userId);
 }

--- a/msa.hub/src/main/java/com/msa/hub/domain/model/BaseEntity.java
+++ b/msa.hub/src/main/java/com/msa/hub/domain/model/BaseEntity.java
@@ -42,4 +42,9 @@ public abstract class BaseEntity {
     @Column(name="deleted_by")
     private String deletedBy;
 
+    public void deleteBase(Long userId) {
+        this.isDeleted = true;
+        this.deletedAt = LocalDateTime.now();
+        this.deletedBy = String.valueOf(userId);
+    }
 }

--- a/msa.hub/src/main/java/com/msa/hub/domain/model/Hub.java
+++ b/msa.hub/src/main/java/com/msa/hub/domain/model/Hub.java
@@ -114,5 +114,14 @@ public class Hub extends BaseEntity {
         if (longitude != null) this.longitude = longitude;
     }
 
+    public void softDeleteHub(Long userId) {
+        this.deleteBase(userId);
+        for (HubRoute route : sourceHubRoutes) {
+            route.softDeleteHubRoute(userId);
+        }
+        for (HubRoute route : destinationHubRoutes) {
+            route.softDeleteHubRoute(userId);
+        }
+    }
 
 }

--- a/msa.hub/src/main/java/com/msa/hub/domain/model/HubRoute.java
+++ b/msa.hub/src/main/java/com/msa/hub/domain/model/HubRoute.java
@@ -70,4 +70,11 @@ public class HubRoute extends BaseEntity {
     public void updateWaypoints(List<Waypoint> waypoints) {
         this.waypoints = waypoints;
     }
+
+    public void softDeleteHubRoute(Long userId) {
+        this.deleteBase(userId);
+        for(Waypoint waypoint : this.waypoints) {
+            waypoint.deleteBase(userId);
+        }
+    }
 }

--- a/msa.hub/src/main/java/com/msa/hub/domain/model/Waypoint.java
+++ b/msa.hub/src/main/java/com/msa/hub/domain/model/Waypoint.java
@@ -18,7 +18,7 @@ import lombok.NoArgsConstructor;
 @Entity
 @Table(name = "p_hub_route_way_point")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class Waypoint {
+public class Waypoint extends BaseEntity {
     @Id
     @GeneratedValue(strategy= GenerationType.UUID)
     @Column(name="id")

--- a/msa.hub/src/main/java/com/msa/hub/infrastructure/UserClient.java
+++ b/msa.hub/src/main/java/com/msa/hub/infrastructure/UserClient.java
@@ -1,15 +1,14 @@
 package com.msa.hub.infrastructure;
 
 
-import com.msa.hub.application.dto.UserDetailResponse;
 import com.msa.hub.application.service.UserService;
-import com.msa.hub.presentation.response.ApiResponse;
 import org.springframework.cloud.openfeign.FeignClient;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 
 @FeignClient(name = "user-service")
 public interface UserClient extends UserService {
-    @GetMapping("/users/{userId}")
-    ApiResponse<UserDetailResponse> findUser(@PathVariable Long userId);
+    @DeleteMapping("/users/belong-hub")
+    Boolean detachBelongHub(@RequestParam Long userId);
+
 }

--- a/msa.hub/src/main/java/com/msa/hub/presentation/controller/HubController.java
+++ b/msa.hub/src/main/java/com/msa/hub/presentation/controller/HubController.java
@@ -15,6 +15,8 @@ import org.springframework.data.domain.Sort.Direction;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.data.web.SortDefault;
 import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -82,6 +84,16 @@ public class HubController {
     ) {
         hubService.updateHubManager(hubId, userId);
         return true;
+    }
+
+    @DeleteMapping("/{hubId}")
+    @PreAuthorize("hasAuthority('MASTER')")
+    public ApiResponse<Void> deleteHub(
+            @PathVariable String hubId,
+            Authentication authentication
+    ) {
+        hubService.deleteHub(hubId, Long.valueOf(authentication.getName()));
+        return ApiResponse.success();
     }
 
     @GetMapping("/verify")

--- a/msa.hub/src/main/java/com/msa/hub/presentation/controller/HubRouteController.java
+++ b/msa.hub/src/main/java/com/msa/hub/presentation/controller/HubRouteController.java
@@ -19,6 +19,8 @@ import org.springframework.data.domain.Sort.Direction;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.data.web.SortDefault;
 import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -88,6 +90,17 @@ public class HubRouteController {
     ) {
         hubRouteUpdateService.updateWaypointDetail(
                 waypointId, request.distanceFromPrevious(), request.durationFromPrevious());
+        return ApiResponse.success();
+    }
+
+    @DeleteMapping("/{hubRouteId}")
+    @PreAuthorize("hasAuthority('MASTER')")
+    public ApiResponse<Void> deleteHubRoute(
+            @PathVariable String hubRouteId,
+            Authentication authentication
+    ) {
+        hubRouteUpdateService.deleteHubRoute(
+                hubRouteId, Long.valueOf(authentication.getName()));
         return ApiResponse.success();
     }
 

--- a/msa.user/src/main/java/com/msa/user/application/service/UserService.java
+++ b/msa.user/src/main/java/com/msa/user/application/service/UserService.java
@@ -64,6 +64,12 @@ public class UserService {
     }
 
     @Transactional
+    public void hubDetach(final Long userId) {
+        User user = getUserOrException(userId);
+        user.setBelongHub(null);
+    }
+
+    @Transactional
     public void deleteUser(final Long userId) {
         User user = getUserOrException(userId);
         user.deleteBase(userId);

--- a/msa.user/src/main/java/com/msa/user/presentation/controller/UserController.java
+++ b/msa.user/src/main/java/com/msa/user/presentation/controller/UserController.java
@@ -82,6 +82,14 @@ public class UserController {
         return ApiResponse.success();
     }
 
+    @DeleteMapping("/belong-hub")
+    public Boolean detachBelongHub(
+            @RequestParam Long userId
+    ) {
+        userService.hubDetach(userId);
+        return true;
+    }
+
     @DeleteMapping
     public ApiResponse<Void> deleteUser(
             Authentication authentication


### PR DESCRIPTION
## Summary
<!-- 해당 PR에 어떤 작업이 포함됐는지 요약해주세요 -->
<!-- merge시 관련 이슈가 자동으로 close 되도록 이슈 번호를 작성해주세요 -->
- closed #66 
- closed #98 

허브, 허브 경로 논리적 삭제 API를 개발했습니다.
허브 삭제 시, 담당자 유저가 있다면 유저 서비스 api 를 호출해 유저의 담당 허브 정보를 삭제합니다
## Key Changes
<!-- 주요 변경 사항을 기재해주세요 -->
- 각 엔티티에 삭제를 위한 메서드 추가
- 유저 api에 담당 허브를 끊는 API 추가 및 허브 서비스에서 해당 api 사용할 수 있도록 설정
## Testing
<!-- 해당 작업이 성공된 것을 확인할 수 있는 방법을 기재해주세요 -->
<!-- 전/후 스크린샷을 첨부하기도 합니다 -->
![image](https://github.com/user-attachments/assets/36d7707d-cbd3-4b81-9d1d-57bce2927191)

데이터베이스에 반영됨을 확인했습니다!
## To Reviewers
<!-- 리뷰어에게 전달하거나 논의하고 싶은 내용을 기재해주세요 -->
- 궁금하신 점, 개선할 점 등 생각나시는 의견 있으시면 편하게 남겨주세요!